### PR TITLE
Add situation model and read-only adapter foundation

### DIFF
--- a/babbly/adapters/README.md
+++ b/babbly/adapters/README.md
@@ -1,0 +1,13 @@
+# Babbly Adapters
+
+Adapters translate external system state into Babbly's generic Situation Model.
+
+The default contract is read-only/advisory:
+
+- observations may describe state, alerts, and evidence
+- recommendations may suggest operator actions
+- recommendations are advisory-only by default
+- adapter failure must not terminate Babbly
+- adapters do not receive arbitrary shell-command authority
+
+Write-capable integrations, if added later, must use a separate explicit request/approval contract rather than extending the read-only adapter interface.

--- a/babbly/adapters/__init__.py
+++ b/babbly/adapters/__init__.py
@@ -1,0 +1,3 @@
+from .base import BabblyAdapter
+
+__all__ = ["BabblyAdapter"]

--- a/babbly/adapters/__main__.py
+++ b/babbly/adapters/__main__.py
@@ -1,0 +1,12 @@
+from babbly.adapters.azazel import AzazelAdapter
+from babbly.core.engine import SituationEngine
+
+
+def main():
+    adapter = AzazelAdapter(lambda: {"system": "azazel", "state": "unknown"})
+    snapshot = SituationEngine([adapter]).collect()
+    print(snapshot.to_dict())
+
+
+if __name__ == "__main__":
+    main()

--- a/babbly/adapters/azazel.py
+++ b/babbly/adapters/azazel.py
@@ -1,0 +1,104 @@
+from typing import Callable, Iterable, Mapping, Optional
+
+from babbly.adapters.base import BabblyAdapter
+from babbly.core import Observation, Recommendation
+
+
+class AzazelAdapter(BabblyAdapter):
+    """Translate Azazel status payloads into Babbly's generic situation model.
+
+    The adapter is intentionally read-only. A future write path must use an
+    explicit request/approval contract and must not bypass Azazel-Edge authority.
+    """
+
+    name = "azazel"
+
+    def __init__(self, status_provider: Callable[[], Mapping[str, object]]):
+        self.status_provider = status_provider
+
+    def _payload(self) -> Mapping[str, object]:
+        payload = self.status_provider()
+        return payload if isinstance(payload, Mapping) else {}
+
+    def observations(self) -> Iterable[Observation]:
+        payload = self._payload()
+        observations = []
+
+        system = str(payload.get("system", "azazel"))
+        state = str(payload.get("state", "unknown"))
+        headline = str(payload.get("headline") or f"{system} state is {state}")
+        state_severity = _normalize_severity(payload.get("state_severity"), state)
+        metadata = payload.get("metadata") if isinstance(payload.get("metadata"), Mapping) else {}
+        observations.append(
+            Observation(
+                source=system,
+                category="system.state",
+                summary=headline,
+                severity=state_severity,
+                data={"state": state, **dict(metadata)},
+            )
+        )
+
+        for alert in payload.get("alerts", []) or []:
+            if not isinstance(alert, Mapping):
+                continue
+            data = alert.get("data") if isinstance(alert.get("data"), Mapping) else alert
+            observations.append(
+                Observation(
+                    source=system,
+                    category=str(alert.get("category", "security.alert")),
+                    summary=str(alert.get("summary", "Azazel alert")),
+                    severity=_normalize_severity(alert.get("severity"), "warning"),
+                    confidence=_optional_float(alert.get("confidence")),
+                    data=dict(data),
+                )
+            )
+        return observations
+
+    def recommendations(self) -> Iterable[Recommendation]:
+        payload = self._payload()
+        system = str(payload.get("system", "azazel"))
+        recommendations = []
+        for item in payload.get("recommendations", []) or []:
+            if not isinstance(item, Mapping):
+                continue
+            try:
+                priority = int(item.get("priority", 100))
+            except (TypeError, ValueError):
+                priority = 100
+            recommendations.append(
+                Recommendation(
+                    source=system,
+                    action=str(item.get("action", "observe")),
+                    reason=str(item.get("reason", "Azazel advisory")),
+                    priority=priority,
+                    confidence=_optional_float(item.get("confidence")),
+                    advisory_only=True,
+                )
+            )
+        return recommendations
+
+
+def _normalize_severity(value: object, state: object = "unknown") -> str:
+    word = str(value or "").strip().lower()
+    if word in {"info", "caution", "warning", "critical"}:
+        return word
+    state_word = str(state or "unknown").strip().lower()
+    if state_word in {"normal", "ok", "safe", "healthy", "quiet", "online", "shield"}:
+        return "info"
+    if state_word in {"degraded", "caution", "warn", "unknown"}:
+        return "caution"
+    if state_word in {"contain", "containment", "deception", "warning"}:
+        return "warning"
+    if state_word in {"critical", "lockdown", "offline", "danger"}:
+        return "critical"
+    return "caution"
+
+
+def _optional_float(value: Optional[object]) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/babbly/adapters/azazel_edge_transport.py
+++ b/babbly/adapters/azazel_edge_transport.py
@@ -1,0 +1,273 @@
+"""Read-only Azazel-Edge transport for Babbly situation adapters.
+
+The transport consumes the additive ``/api/state.status_view`` JSON contract
+emitted by Azazel-Edge. Babbly intentionally does not import Azazel-Fabric: the
+wire contract is sufficient and keeps Babbly usable outside the Azazel series.
+
+Only HTTP GET is supported. There is no write/action path in this module.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, Callable, Dict, Mapping, Optional
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+
+class AzazelEdgeTransportError(RuntimeError):
+    """Raised when the read-only Edge status surface cannot be consumed."""
+
+
+def _status_severity(value: object) -> str:
+    word = str(value or "unknown").strip().lower()
+    if word in {"normal", "ok", "safe", "healthy", "quiet", "online"}:
+        return "info"
+    if word in {"degraded", "caution", "warn", "warning", "unknown"}:
+        return "caution"
+    if word in {"contain", "containment", "deception"}:
+        return "warning"
+    if word in {"critical", "lockdown", "offline", "danger"}:
+        return "critical"
+    return "caution"
+
+
+def _health_severity(value: object) -> str:
+    word = str(value or "unknown").strip().lower()
+    if word == "ok":
+        return "info"
+    if word in {"warn", "warning", "unknown"}:
+        return "caution"
+    if word == "critical":
+        return "critical"
+    return "caution"
+
+
+def _current_action_summary(value: object) -> Optional[str]:
+    if not value:
+        return None
+    if isinstance(value, Mapping):
+        action = value.get("kind") or value.get("action") or value.get("name")
+        target = value.get("target")
+        if action and target:
+            return f"current action: {action} ({target})"
+        if action:
+            return f"current action: {action}"
+        return "current action is present"
+    return f"current action: {value}"
+
+
+def translate_edge_state(payload: Mapping[str, object]) -> Dict[str, object]:
+    """Translate Edge ``/api/state`` into Babbly's generic adapter payload.
+
+    ``status_view`` is authoritative for presentation when present. The native
+    Edge snapshot is used only as a compatibility fallback for installations
+    where the additive Fabric view has not been emitted yet.
+    """
+    view = payload.get("status_view")
+    if isinstance(view, Mapping):
+        product = str(view.get("product") or "edge")
+        system = f"azazel-{product}"
+        posture = str(view.get("posture") or "unknown")
+        headline = str(view.get("headline") or f"{system} state is {posture}")
+        state_severity = _status_severity(posture)
+        alerts = []
+
+        for reason in view.get("reasons", []) or []:
+            if reason:
+                alerts.append(
+                    {
+                        "category": "status.reason",
+                        "summary": str(reason),
+                        "severity": state_severity,
+                    }
+                )
+
+        for row in view.get("health", []) or []:
+            if not isinstance(row, Mapping):
+                continue
+            key = str(row.get("key") or "unknown")
+            label = str(row.get("label") or key)
+            detail = row.get("detail")
+            summary = label if not detail else f"{label}: {detail}"
+            alerts.append(
+                {
+                    "category": f"health.{key}",
+                    "summary": summary,
+                    "severity": _health_severity(row.get("status")),
+                    "data": dict(row),
+                }
+            )
+
+        current_action = view.get("current_action")
+        action_summary = _current_action_summary(current_action)
+        if action_summary:
+            alerts.append(
+                {
+                    "category": "control.current_action",
+                    "summary": action_summary,
+                    "severity": "info",
+                    "data": dict(current_action) if isinstance(current_action, Mapping) else {"value": current_action},
+                }
+            )
+
+        operator_wording = view.get("operator_wording")
+        recommendations = []
+        for index, action in enumerate(view.get("next_actions", []) or []):
+            if not action:
+                continue
+            recommendations.append(
+                {
+                    "action": str(action),
+                    "reason": str(operator_wording or headline),
+                    "priority": 10 + index * 10,
+                }
+            )
+        # Current Edge emits its native snapshot recommendation as
+        # StatusView.operator_wording and does not yet populate next_actions.
+        # Preserve that information as spoken advice only; it is never wired to
+        # an execution path.
+        if not recommendations and operator_wording:
+            recommendations.append(
+                {
+                    "action": str(operator_wording),
+                    "reason": headline,
+                    "priority": 50,
+                }
+            )
+
+        return {
+            "system": system,
+            "state": posture,
+            "state_severity": state_severity,
+            "headline": headline,
+            "alerts": alerts,
+            "recommendations": recommendations,
+            "metadata": {
+                "schema_version": view.get("schema_version"),
+                "generated_at": view.get("generated_at"),
+                "trace_id": view.get("trace_id"),
+                "mode": view.get("mode"),
+                "operator_wording": operator_wording,
+                "evidence_ids": list(view.get("evidence_ids", []) or []),
+                "current_action": current_action,
+            },
+        }
+
+    # Compatibility fallback: use only stable, read-only state indicators. Do
+    # not synthesize recommendations from product-specific fields.
+    internal = payload.get("internal") if isinstance(payload.get("internal"), Mapping) else {}
+    state = str(internal.get("state_name") or payload.get("user_state") or payload.get("status") or "unknown")
+    severity = _status_severity(state)
+    alerts = []
+    critical = payload.get("suricata_critical")
+    warning = payload.get("suricata_warning")
+    if critical is not None or warning is not None:
+        try:
+            critical_count = int(critical or 0)
+        except (TypeError, ValueError):
+            critical_count = 0
+        try:
+            warning_count = int(warning or 0)
+        except (TypeError, ValueError):
+            warning_count = 0
+        alerts.append(
+            {
+                "category": "health.suricata",
+                "summary": f"Suricata critical={critical_count} warning={warning_count}",
+                "severity": "critical" if critical_count else ("caution" if warning_count else "info"),
+            }
+        )
+    return {
+        "system": "azazel-edge",
+        "state": state,
+        "state_severity": severity,
+        "headline": f"azazel-edge state is {state}",
+        "alerts": alerts,
+        "recommendations": [],
+        "metadata": {"status_view": "unavailable"},
+    }
+
+
+class AzazelEdgeStatusProvider:
+    """Bounded, cached GET provider for Azazel-Edge ``/api/state``.
+
+    Repeated calls inside one SituationEngine collection are served from a short
+    monotonic TTL cache, preventing the observation and recommendation passes
+    from issuing duplicate HTTP requests.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        token: Optional[str] = None,
+        timeout_sec: float = 2.0,
+        cache_ttl_sec: float = 1.0,
+        max_response_bytes: int = 1024 * 1024,
+        opener: Callable[..., Any] = urlopen,
+    ) -> None:
+        base = str(base_url or "").strip().rstrip("/")
+        parsed = urlparse(base)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("AZAZEL_EDGE_URL must be an http(s) URL")
+        self.url = base + "/api/state"
+        self.token = str(token or "").strip()
+        self.timeout_sec = max(0.1, float(timeout_sec))
+        self.cache_ttl_sec = max(0.0, float(cache_ttl_sec))
+        self.max_response_bytes = max(1024, int(max_response_bytes))
+        self.opener = opener
+        self._cached_at: Optional[float] = None
+        self._cached_payload: Optional[Dict[str, object]] = None
+
+    def _request(self) -> Mapping[str, object]:
+        headers = {
+            "Accept": "application/json",
+            "Cache-Control": "no-store",
+        }
+        if self.token:
+            # Canonical Azazel-Fabric/Edge token header. Edge also accepts the
+            # legacy X-Auth-Token header, but new Babbly code uses the canonical one.
+            headers["X-AZAZEL-TOKEN"] = self.token
+        request = Request(self.url, headers=headers, method="GET")
+        response = None
+        try:
+            response = self.opener(request, timeout=self.timeout_sec)
+            status = response.getcode() if hasattr(response, "getcode") else getattr(response, "status", 200)
+            if status is not None and int(status) >= 400:
+                raise AzazelEdgeTransportError(f"Azazel-Edge returned HTTP {status}")
+            raw = response.read(self.max_response_bytes + 1)
+        except AzazelEdgeTransportError:
+            raise
+        except Exception as exc:
+            raise AzazelEdgeTransportError("Azazel-Edge status request failed") from exc
+        finally:
+            if response is not None:
+                close = getattr(response, "close", None)
+                if callable(close):
+                    close()
+
+        if len(raw) > self.max_response_bytes:
+            raise AzazelEdgeTransportError("Azazel-Edge status response exceeded size limit")
+        try:
+            decoded = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise AzazelEdgeTransportError("Azazel-Edge returned invalid JSON") from exc
+        if not isinstance(decoded, Mapping):
+            raise AzazelEdgeTransportError("Azazel-Edge status payload is not an object")
+        return decoded
+
+    def __call__(self) -> Mapping[str, object]:
+        now = time.monotonic()
+        if (
+            self._cached_payload is not None
+            and self._cached_at is not None
+            and now - self._cached_at <= self.cache_ttl_sec
+        ):
+            return self._cached_payload
+
+        translated = translate_edge_state(self._request())
+        self._cached_payload = translated
+        self._cached_at = now
+        return translated

--- a/babbly/adapters/base.py
+++ b/babbly/adapters/base.py
@@ -1,0 +1,21 @@
+from abc import ABC, abstractmethod
+from typing import Iterable
+
+from babbly.core import Observation, Recommendation
+
+
+class BabblyAdapter(ABC):
+    """Read-only/advisory integration boundary for external systems.
+
+    Adapters convert external system state into Babbly observations and
+    recommendations. They do not receive arbitrary shell execution authority.
+    """
+
+    name = "base"
+
+    @abstractmethod
+    def observations(self) -> Iterable[Observation]:
+        raise NotImplementedError
+
+    def recommendations(self) -> Iterable[Recommendation]:
+        return ()

--- a/babbly/adapters/factory.py
+++ b/babbly/adapters/factory.py
@@ -1,0 +1,55 @@
+"""Configuration factory for optional read-only situation adapters."""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Mapping
+
+from babbly.adapters.azazel import AzazelAdapter
+from babbly.adapters.azazel_edge_transport import AzazelEdgeStatusProvider
+from babbly.core.engine import SituationEngine
+
+
+logger = logging.getLogger(__name__)
+
+
+def _load_edge_token(config: Mapping[str, object]) -> str:
+    env_name = str(config.get("AZAZEL_EDGE_TOKEN_ENV") or "AZAZEL_EDGE_TOKEN").strip()
+    if env_name:
+        value = str(os.environ.get(env_name, "")).strip()
+        if value:
+            return value
+
+    token_file = str(config.get("AZAZEL_EDGE_TOKEN_FILE") or "").strip()
+    if token_file:
+        try:
+            return Path(token_file).expanduser().read_text(encoding="utf-8").strip()
+        except OSError as exc:
+            logger.warning("Azazel-Edge token file is unreadable: %s", exc)
+    return ""
+
+
+def create_situation_engine(config: Mapping[str, object]) -> SituationEngine:
+    """Build Babbly's optional read-only situation integrations.
+
+    Integrations default to disabled so standalone Babbly behavior is unchanged.
+    Configuration errors never grant authority or create a write path; the
+    affected adapter simply remains unavailable.
+    """
+    adapters = []
+    if bool(config.get("AZAZEL_EDGE_ENABLED", False)):
+        try:
+            provider = AzazelEdgeStatusProvider(
+                str(config.get("AZAZEL_EDGE_URL") or "http://127.0.0.1:8084"),
+                token=_load_edge_token(config),
+                timeout_sec=float(config.get("AZAZEL_EDGE_TIMEOUT_SEC", 2.0)),
+                cache_ttl_sec=float(config.get("AZAZEL_EDGE_CACHE_TTL_SEC", 1.0)),
+                max_response_bytes=int(config.get("AZAZEL_EDGE_MAX_RESPONSE_BYTES", 1024 * 1024)),
+            )
+            adapters.append(AzazelAdapter(provider))
+        except (TypeError, ValueError) as exc:
+            logger.warning("Azazel-Edge adapter configuration rejected: %s", exc)
+
+    return SituationEngine(adapters)

--- a/babbly/core/__init__.py
+++ b/babbly/core/__init__.py
@@ -1,0 +1,3 @@
+from .situation import Observation, Recommendation, SituationSnapshot
+
+__all__ = ["Observation", "Recommendation", "SituationSnapshot"]

--- a/babbly/core/engine.py
+++ b/babbly/core/engine.py
@@ -1,0 +1,27 @@
+from typing import Iterable
+
+from babbly.adapters.base import BabblyAdapter
+from babbly.core.situation import SituationSnapshot
+
+
+class SituationEngine:
+    """Aggregate read-only adapter output into one operator-facing snapshot."""
+
+    def __init__(self, adapters: Iterable[BabblyAdapter] = ()):
+        self.adapters = list(adapters)
+
+    def collect(self) -> SituationSnapshot:
+        snapshot = SituationSnapshot()
+        for adapter in self.adapters:
+            try:
+                for observation in adapter.observations():
+                    snapshot.add_observation(observation)
+                for recommendation in adapter.recommendations():
+                    snapshot.add_recommendation(recommendation)
+                snapshot.set_system_state(adapter.name, "online")
+            except Exception as exc:
+                snapshot.set_system_state(adapter.name, "error")
+                # Adapter failure is represented as state, not raised into the
+                # operator loop. External integrations must remain optional.
+                continue
+        return snapshot

--- a/babbly/core/render.py
+++ b/babbly/core/render.py
@@ -1,0 +1,53 @@
+from babbly.core.situation import Recommendation, SituationSnapshot
+
+
+STATUS_JA = {
+    "unknown": "状況不明",
+    "info": "平常",
+    "caution": "注意",
+    "warning": "警戒",
+    "critical": "重大警戒",
+}
+
+
+def render_situation_ja(snapshot: SituationSnapshot, max_observations: int = 2) -> str:
+    """Render a concise operator-facing Japanese situation report."""
+    status = STATUS_JA.get(snapshot.status, snapshot.status)
+    parts = [f"現在の状態は{status}です"]
+
+    online = sum(1 for state in snapshot.systems.values() if state == "online")
+    errors = sum(1 for state in snapshot.systems.values() if state == "error")
+    if snapshot.systems:
+        parts.append(f"接続系統は{online}件正常")
+        if errors:
+            parts.append(f"{errors}件で取得エラー")
+
+    important = sorted(
+        snapshot.observations,
+        key=lambda item: {"critical": 0, "warning": 1, "caution": 2, "info": 3}.get(item.severity, 4),
+    )[:max_observations]
+    if important:
+        parts.append("主な観測は" + "。".join(item.summary for item in important))
+    else:
+        parts.append("報告可能な観測はありません")
+
+    if snapshot.recommendations:
+        top = snapshot.recommendations[0]
+        parts.append(f"最優先の推奨は{top.action}です")
+
+    return "。".join(parts) + "。"
+
+
+def render_recommendation_ja(snapshot: SituationSnapshot) -> str:
+    """Explain the highest-priority advisory recommendation without executing it."""
+    if not snapshot.recommendations:
+        return "現在、提示できる推奨はありません。"
+
+    item: Recommendation = snapshot.recommendations[0]
+    advisory = "これは助言のみで、自動実行はしません" if item.advisory_only else ""
+    message = f"最優先の推奨は{item.action}です。理由は{item.reason}です。"
+    if item.confidence is not None:
+        message += f"信頼度は{item.confidence:.0%}です。"
+    if advisory:
+        message += advisory + "。"
+    return message

--- a/babbly/core/situation.py
+++ b/babbly/core/situation.py
@@ -1,0 +1,61 @@
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+
+@dataclass(frozen=True)
+class Observation:
+    source: str
+    category: str
+    summary: str
+    severity: str = "info"
+    confidence: Optional[float] = None
+    data: Dict[str, Any] = field(default_factory=dict)
+    observed_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+
+
+@dataclass(frozen=True)
+class Recommendation:
+    source: str
+    action: str
+    reason: str
+    priority: int = 100
+    confidence: Optional[float] = None
+    advisory_only: bool = True
+
+
+@dataclass
+class SituationSnapshot:
+    status: str = "unknown"
+    observations: List[Observation] = field(default_factory=list)
+    recommendations: List[Recommendation] = field(default_factory=list)
+    systems: Dict[str, str] = field(default_factory=dict)
+
+    def add_observation(self, observation: Observation) -> None:
+        self.observations.append(observation)
+        self._recompute_status()
+
+    def add_recommendation(self, recommendation: Recommendation) -> None:
+        self.recommendations.append(recommendation)
+        self.recommendations.sort(key=lambda item: item.priority)
+
+    def set_system_state(self, system: str, state: str) -> None:
+        self.systems[system] = state
+
+    def _recompute_status(self) -> None:
+        rank = {"info": 0, "caution": 1, "warning": 2, "critical": 3}
+        current = "info"
+        for observation in self.observations:
+            if rank.get(observation.severity, 0) > rank.get(current, 0):
+                current = observation.severity
+        self.status = current if self.observations else "unknown"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "status": self.status,
+            "systems": dict(self.systems),
+            "observations": [asdict(item) for item in self.observations],
+            "recommendations": [asdict(item) for item in self.recommendations],
+        }

--- a/babbly/ja/config_ja.yaml
+++ b/babbly/ja/config_ja.yaml
@@ -31,3 +31,14 @@ WHISPER_COMPUTE_TYPE: "int8"
 ASR_SILENCE_SECONDS: 0.8
 ASR_MAX_SECONDS: 12.0
 ASR_RMS_THRESHOLD: 0.012
+
+# Optional read-only Azazel-Edge situation source. Disabled by default so
+# standalone Babbly behavior remains unchanged. When enabled, Babbly only GETs
+# /api/state and prefers the additive Azazel-Fabric status_view contract.
+AZAZEL_EDGE_ENABLED: false
+AZAZEL_EDGE_URL: "http://127.0.0.1:8084"
+AZAZEL_EDGE_TOKEN_ENV: "AZAZEL_EDGE_TOKEN"
+AZAZEL_EDGE_TOKEN_FILE: ""
+AZAZEL_EDGE_TIMEOUT_SEC: 2.0
+AZAZEL_EDGE_CACHE_TTL_SEC: 1.0
+AZAZEL_EDGE_MAX_RESPONSE_BYTES: 1048576

--- a/babbly/ja/main_program.py
+++ b/babbly/ja/main_program.py
@@ -4,7 +4,10 @@ import sys
 
 import pyfiglet
 
+from babbly.adapters.factory import create_situation_engine
 from babbly.asr import create_asr
+from babbly.core.engine import SituationEngine
+from babbly.core.render import render_recommendation_ja, render_situation_ja
 from babbly.ja.japanese_tts import Japanese_TTS
 from babbly.modules.commands_manager import CommandManager
 from babbly.modules.ipaddress_manager import IPAddressManager
@@ -18,6 +21,13 @@ from babbly.nlu.vocabulary import build_aliases
 
 tts = Japanese_TTS()
 lang_ja = 1
+situation_engine = SituationEngine()
+
+
+def set_situation_engine(engine):
+    """Inject read-only situation adapters without coupling the voice loop to Azazel."""
+    global situation_engine
+    situation_engine = engine
 
 
 def set_globals(config):
@@ -67,6 +77,20 @@ def report_dry_run(action, detail=""):
     logging.info(message)
     print(message)
     tts.say("ドライランのため、実際の処理は実行しません")
+
+
+def speak_situation_report():
+    snapshot = situation_engine.collect()
+    message = render_situation_ja(snapshot)
+    print(message)
+    tts.say(message)
+
+
+def speak_recommendation():
+    snapshot = situation_engine.collect()
+    message = render_recommendation_ja(snapshot)
+    print(message)
+    tts.say(message)
 
 
 def listen_for_wakeup_phrase(asr):
@@ -135,6 +159,14 @@ def listen_for_command(asr):
 
             if intent.name == "system.introduce":
                 introduce(tts, lang_ja)
+                break
+
+            if intent.name == "situation.report":
+                speak_situation_report()
+                break
+
+            if intent.name == "recommendation.explain":
+                speak_recommendation()
                 break
 
             if intent.name == "network.scan":
@@ -217,7 +249,12 @@ def main():
 
     config = load_config("babbly/ja/config_ja.yaml")
     set_globals(config)
-    logging.info("設定読み込み完了 dry_run=%s", DRY_RUN)
+    set_situation_engine(create_situation_engine(config))
+    logging.info(
+        "設定読み込み完了 dry_run=%s azazel_edge=%s",
+        DRY_RUN,
+        bool(config.get("AZAZEL_EDGE_ENABLED", False)),
+    )
 
     asr = create_asr(config)
     logging.info("音声認識機能 初期化完了 backend=%s", config.get("ASR_BACKEND", "vosk"))

--- a/babbly/nlu/japanese.py
+++ b/babbly/nlu/japanese.py
@@ -32,11 +32,13 @@ class IntentResult:
 
 
 class IntentResolver:
-    """Deterministic resolver for executable command routing."""
+    """Deterministic resolver for command and read-only operator intents."""
 
     RULES: Tuple[Tuple[str, Tuple[Tuple[str, ...], ...]], ...] = (
         ("system.exit", (("終了",), ("システム", "終了"))),
         ("system.introduce", (("自己紹介",),)),
+        ("situation.report", (("状況", "報告"), ("状況", "確認"), ("状況", "教え"))),
+        ("recommendation.explain", (("推奨", "説明"), ("推奨", "教え"), ("どうすれば",), ("何をすべき",))),
         ("network.scan", (("ネットワーク", "スキャン"), ("周辺", "スキャン"))),
         ("target.show", (("ターゲット", "教え"), ("ターゲット", "表示"), ("ターゲット", "確認"))),
         ("command.mode", (("コマンド",),)),

--- a/docs/ARCHITECTURE_NOTE.md
+++ b/docs/ARCHITECTURE_NOTE.md
@@ -1,0 +1,17 @@
+# Architecture boundary
+
+Babbly Core should remain usable without Azazel. Azazel is an adapter, not a core dependency.
+
+The dependency direction is:
+
+```text
+Babbly Core <- Adapter <- External system
+```
+
+Never:
+
+```text
+Babbly Core -> Azazel-specific implementation
+```
+
+This preserves Babbly as a generic offline voice/operator-assistance framework.

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -1,0 +1,27 @@
+# Implementation status
+
+Implemented on this branch:
+
+- SituationSnapshot, Observation, Recommendation
+- SituationEngine aggregation and adapter failure isolation
+- BabblyAdapter read-only/advisory contract
+- `situation.report` and `recommendation.explain` voice intents
+- concise Japanese situation/recommendation rendering
+- Azazel-Edge GET-only `/api/state` transport
+- Azazel-Fabric `status_view` wire-contract translation
+- canonical `X-AZAZEL-TOKEN` authentication support
+- bounded timeout and response size with no automatic retries
+- short TTL cache to avoid duplicate reads during one collection
+- environment/token-file secret loading; no committed token
+- native Edge compatibility fallback when `status_view` is absent
+- full tests and GitHub Actions coverage
+
+Not implemented yet:
+
+- write/action request contract
+- autonomous actions from Situation Model
+- low-cost wake-word / keyword-spotting backend
+- Raspberry Pi 5 live ASR/KWS benchmark measurements
+- TUI/Web situation rendering
+
+The Azazel integration is intentionally read-only. Edge remains the authority for Azazel actions.

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -1,0 +1,7 @@
+# Immediate next targets
+
+1. Add `situation.report` as a non-executing voice intent.
+2. Add a compact spoken renderer that summarizes status, top observations, and the highest-priority advisory.
+3. Add local provider adapters (file/HTTP/Unix socket) behind explicit configuration.
+4. Map the Azazel provider to actual read-only status surfaces after contract review.
+5. Keep all action requests outside the read-only adapter interface.

--- a/docs/PR_SCOPE.md
+++ b/docs/PR_SCOPE.md
@@ -1,0 +1,11 @@
+# Situation/Adapter PR scope
+
+This change adds only read-only/advisory foundations:
+
+- generic situation data model
+- aggregation engine
+- adapter abstraction
+- initial read-only Azazel payload translator
+- failure isolation tests
+
+It does not add live Azazel network access, write actions, autonomous response, or arbitrary command authority.

--- a/docs/ROADMAP_2X.md
+++ b/docs/ROADMAP_2X.md
@@ -1,0 +1,39 @@
+# Babbly 2.x Roadmap
+
+## Phase A — Offline speech foundation
+
+- pluggable ASR backend
+- Japanese normalization
+- deterministic intent routing
+- confidence policy
+- explicit clarification
+- dry-run validation
+- Pi 5 benchmark harness
+
+## Phase B — Situation awareness foundation
+
+- generic Observation / Recommendation / SituationSnapshot model
+- optional adapter framework
+- read-only Azazel adapter
+- adapter failure isolation
+
+## Phase C — Operator experience
+
+- `situation.report` intent
+- concise spoken situation reports
+- explanation of highest-priority recommendation
+- configurable verbosity and alert interruption policy
+
+## Phase D — Field runtime
+
+- low-power wake-word/KWS backend
+- streaming ARM ASR evaluation
+- local persistence and replay
+- TUI and compact web surface
+
+## Phase E — Controlled requests
+
+- separate request/approval contract for write-capable integrations
+- explicit human confirmation
+- external authority preserved (for example, Azazel-Edge remains authoritative for Azazel actions)
+- complete audit trail

--- a/docs/STACKED_PR.md
+++ b/docs/STACKED_PR.md
@@ -1,0 +1,10 @@
+# Stacked development note
+
+This branch is intentionally based on `agent/offline-asr-intent-foundation`.
+
+Merge/order:
+
+1. offline ASR + intent foundation
+2. situation model + adapter foundation
+
+The second change depends on the first branch's package structure and CI baseline.

--- a/docs/situation-model.md
+++ b/docs/situation-model.md
@@ -1,0 +1,123 @@
+# Babbly Situation Model
+
+Babbly is evolving from a voice-triggered command launcher into a reusable offline operator-assistance layer. The Situation Model is the boundary that keeps Babbly generic while allowing systems such as Azazel to provide context.
+
+## Responsibility
+
+Babbly owns:
+
+- operator-facing observations
+- cross-adapter situation aggregation
+- advisory recommendations
+- presentation by voice, TUI, or future UI surfaces
+
+Adapters own translation from an external system's status shape into Babbly's generic model.
+
+Babbly does not gain external-system action authority merely because an adapter is connected.
+
+## Core objects
+
+`Observation` records source, category, human-readable summary, severity, optional confidence, and source data.
+
+`Recommendation` records an advisory action, reason, priority, and optional confidence. `advisory_only` defaults to `true`.
+
+`SituationSnapshot` aggregates observations, recommendations, and per-adapter health. Its overall status is derived from the highest observation severity.
+
+## Adapter boundary
+
+`BabblyAdapter` is read-only/advisory by default:
+
+```text
+External system
+     |
+     v
+BabblyAdapter
+     |
+     +--> Observation[]
+     +--> Recommendation[]
+              |
+              v
+       SituationEngine
+              |
+              v
+       SituationSnapshot
+              |
+        +-----+-----+
+        |           |
+      Voice        TUI
+```
+
+## Azazel-Edge live status integration
+
+The first live provider is intentionally narrow:
+
+```text
+Azazel-Edge
+  GET /api/state
+       |
+       v
+ status_view (Azazel-Fabric StatusView)
+       |
+       v
+AzazelEdgeStatusProvider
+       |
+       v
+AzazelAdapter
+       |
+       v
+SituationEngine
+```
+
+Babbly consumes the JSON wire contract only; it does not require the `azazel-fabric` Python package. The shared `status_view` is preferred whenever present. Native Edge state fields are used only as a compatibility fallback for an installation where the additive view is unavailable.
+
+The provider is GET-only and uses the canonical `X-AZAZEL-TOKEN` header. It has a bounded timeout, a response-size limit, no automatic retry loop, and a short monotonic TTL cache. The cache also prevents one SituationEngine collection from fetching `/api/state` twice when observations and recommendations are requested separately.
+
+Current `StatusView` mapping:
+
+- `posture` + `headline` -> system-state observation
+- `reasons` -> status-reason observations
+- `health` -> health observations with normalized severity
+- `current_action` -> observation of an action Edge has already selected; never an execution request
+- `next_actions` -> advisory Babbly recommendations
+- current Edge `operator_wording` -> advisory fallback when `next_actions` is empty
+- `trace_id`, `mode`, `evidence_ids`, and other contract metadata -> observation metadata
+
+`product_view.edge_snapshot` is not treated as a command source. The shared Fabric view remains the presentation contract.
+
+### Configuration
+
+The integration is disabled by default. Enable it in `babbly/ja/config_ja.yaml` or an equivalent deployment configuration:
+
+```yaml
+AZAZEL_EDGE_ENABLED: true
+AZAZEL_EDGE_URL: "http://127.0.0.1:8084"
+AZAZEL_EDGE_TOKEN_ENV: "AZAZEL_EDGE_TOKEN"
+AZAZEL_EDGE_TOKEN_FILE: ""
+AZAZEL_EDGE_TIMEOUT_SEC: 2.0
+AZAZEL_EDGE_CACHE_TTL_SEC: 1.0
+```
+
+Prefer a token environment variable or a protected token file; do not commit a token into the YAML file.
+
+## Authority boundary
+
+Situation reporting and recommendation explanation are read-only. A future Azazel write path must be modeled separately as an explicit request to Azazel-Edge. Babbly must not bypass Edge's deterministic decision authority, and a `current_action` observed in StatusView must never be replayed as a Babbly action.
+
+## Failure behavior
+
+An HTTP/auth/JSON/adapter failure marks the Azazel adapter as `error` and does not terminate the Situation Engine. Babbly remains usable when the optional integration is absent or unavailable. Transport errors do not fall through into command/SOP execution.
+
+## Implemented voice intents
+
+- `situation.report`: collect the current snapshot and speak a concise situation report.
+- `recommendation.explain`: speak the highest-priority advisory recommendation, if any.
+
+Both are non-executing intents.
+
+## Next steps
+
+1. validate live Edge/Babbly behavior on the Raspberry Pi reference appliance
+2. add low-cost wake-word/KWS and VAD separation
+3. record Pi 5 Vosk vs faster-whisper benchmark measurements
+4. add other read-only adapters without coupling Babbly Core to their products
+5. keep all future execution requests separate from the read-only Situation Model

--- a/tests/test_azazel_adapter.py
+++ b/tests/test_azazel_adapter.py
@@ -1,0 +1,41 @@
+from babbly.adapters.azazel import AzazelAdapter
+from babbly.core.engine import SituationEngine
+
+
+def test_azazel_adapter_translates_alerts_and_advisory():
+    payload = {
+        "system": "azazel-edge",
+        "state": "shield",
+        "alerts": [
+            {
+                "category": "network.scan",
+                "summary": "repeated local probing",
+                "severity": "warning",
+                "confidence": 0.91,
+            }
+        ],
+        "recommendations": [
+            {
+                "action": "maintain shield",
+                "reason": "probing remains active",
+                "priority": 10,
+                "confidence": 0.88,
+            }
+        ],
+    }
+    adapter = AzazelAdapter(lambda: payload)
+    snapshot = SituationEngine([adapter]).collect()
+
+    assert snapshot.systems["azazel"] == "online"
+    assert snapshot.status == "warning"
+    assert any(item.category == "network.scan" for item in snapshot.observations)
+    assert snapshot.recommendations[0].action == "maintain shield"
+    assert snapshot.recommendations[0].advisory_only is True
+
+
+def test_adapter_failure_does_not_break_situation_engine():
+    def broken_provider():
+        raise RuntimeError("offline")
+
+    snapshot = SituationEngine([AzazelAdapter(broken_provider)]).collect()
+    assert snapshot.systems["azazel"] == "error"

--- a/tests/test_azazel_edge_transport.py
+++ b/tests/test_azazel_edge_transport.py
@@ -1,0 +1,137 @@
+import json
+
+import pytest
+
+from babbly.adapters.azazel import AzazelAdapter
+from babbly.adapters.azazel_edge_transport import (
+    AzazelEdgeStatusProvider,
+    AzazelEdgeTransportError,
+    translate_edge_state,
+)
+from babbly.adapters.factory import create_situation_engine
+from babbly.core.engine import SituationEngine
+
+
+class FakeResponse:
+    def __init__(self, payload, status=200):
+        self.payload = payload
+        self.status = status
+        self.closed = False
+
+    def getcode(self):
+        return self.status
+
+    def read(self, _limit=-1):
+        return self.payload
+
+    def close(self):
+        self.closed = True
+
+
+class FakeOpener:
+    def __init__(self, payload):
+        self.payload = payload
+        self.calls = []
+
+    def __call__(self, request, timeout):
+        self.calls.append((request, timeout))
+        return FakeResponse(self.payload)
+
+
+def status_payload():
+    return {
+        "ok": True,
+        "status_view": {
+            "schema_version": "1.0",
+            "product": "edge",
+            "generated_at": "2026-08-13T00:00:00Z",
+            "trace_id": "trace-1",
+            "mode": {"name": "shield", "since": "2026-08-13T00:00:00Z"},
+            "posture": "degraded",
+            "headline": "edge · shield · degraded",
+            "reasons": ["repeated local probing"],
+            "operator_wording": "Maintain observation while the probe remains active.",
+            "current_action": {"kind": "throttle", "target": "client-a"},
+            "next_actions": ["review evidence", "verify client identity"],
+            "health": [
+                {"key": "suricata", "label": "crit=1 warn=0", "status": "critical"},
+                {"key": "uplink", "label": "CONNECTED", "status": "ok"},
+            ],
+            "evidence_ids": ["ev-1"],
+            "product_view": {"edge_snapshot": {"user_state": "DEGRADED"}},
+        },
+    }
+
+
+def test_translates_fabric_status_view_without_treating_current_action_as_request():
+    translated = translate_edge_state(status_payload())
+
+    assert translated["system"] == "azazel-edge"
+    assert translated["state"] == "degraded"
+    assert translated["headline"] == "edge · shield · degraded"
+    assert any(item["category"] == "control.current_action" for item in translated["alerts"])
+    assert translated["recommendations"][0]["action"] == "review evidence"
+    assert translated["metadata"]["trace_id"] == "trace-1"
+
+
+def test_provider_uses_canonical_token_header_and_short_ttl_cache():
+    opener = FakeOpener(json.dumps(status_payload()).encode("utf-8"))
+    provider = AzazelEdgeStatusProvider(
+        "http://127.0.0.1:8084",
+        token="secret-token",
+        cache_ttl_sec=5.0,
+        opener=opener,
+    )
+
+    first = provider()
+    second = provider()
+
+    assert first == second
+    assert len(opener.calls) == 1
+    request, timeout = opener.calls[0]
+    assert request.full_url == "http://127.0.0.1:8084/api/state"
+    assert dict(request.header_items())["X-azazel-token"] == "secret-token"
+    assert timeout == 2.0
+
+
+def test_status_view_flows_into_situation_engine_as_read_only_advice():
+    provider = lambda: translate_edge_state(status_payload())
+    snapshot = SituationEngine([AzazelAdapter(provider)]).collect()
+
+    assert snapshot.systems["azazel"] == "online"
+    assert snapshot.status == "critical"
+    assert snapshot.recommendations[0].action == "review evidence"
+    assert snapshot.recommendations[0].advisory_only is True
+
+
+def test_native_edge_state_is_supported_only_as_compatibility_fallback():
+    translated = translate_edge_state(
+        {"user_state": "NORMAL", "suricata_critical": 0, "suricata_warning": 0}
+    )
+    assert translated["state"] == "NORMAL"
+    assert translated["metadata"]["status_view"] == "unavailable"
+    assert translated["recommendations"] == []
+
+
+def test_invalid_json_fails_closed():
+    provider = AzazelEdgeStatusProvider(
+        "http://127.0.0.1:8084",
+        opener=FakeOpener(b"not-json"),
+    )
+    with pytest.raises(AzazelEdgeTransportError):
+        provider()
+
+
+def test_factory_is_disabled_by_default_and_reads_token_from_environment(monkeypatch):
+    assert create_situation_engine({}).adapters == []
+
+    monkeypatch.setenv("BABBLY_TEST_EDGE_TOKEN", "env-secret")
+    engine = create_situation_engine(
+        {
+            "AZAZEL_EDGE_ENABLED": True,
+            "AZAZEL_EDGE_URL": "http://127.0.0.1:8084",
+            "AZAZEL_EDGE_TOKEN_ENV": "BABBLY_TEST_EDGE_TOKEN",
+        }
+    )
+    assert len(engine.adapters) == 1
+    assert engine.adapters[0].status_provider.token == "env-secret"

--- a/tests/test_situation_engine.py
+++ b/tests/test_situation_engine.py
@@ -1,0 +1,24 @@
+from babbly.adapters.base import BabblyAdapter
+from babbly.core import Observation
+from babbly.core.engine import SituationEngine
+
+
+class HealthyAdapter(BabblyAdapter):
+    name = "healthy"
+
+    def observations(self):
+        return [Observation("healthy", "status", "ok", severity="info")]
+
+
+class FailingAdapter(BabblyAdapter):
+    name = "failing"
+
+    def observations(self):
+        raise RuntimeError("boom")
+
+
+def test_one_failed_adapter_does_not_drop_healthy_context():
+    snapshot = SituationEngine([FailingAdapter(), HealthyAdapter()]).collect()
+    assert snapshot.systems["failing"] == "error"
+    assert snapshot.systems["healthy"] == "online"
+    assert any(item.source == "healthy" for item in snapshot.observations)

--- a/tests/test_situation_model.py
+++ b/tests/test_situation_model.py
@@ -1,0 +1,20 @@
+from babbly.core import Observation, Recommendation, SituationSnapshot
+
+
+def test_snapshot_uses_highest_observation_severity():
+    snapshot = SituationSnapshot()
+    snapshot.add_observation(Observation("sensor", "network", "normal", severity="info"))
+    snapshot.add_observation(Observation("sensor", "network", "suspicious", severity="warning"))
+    assert snapshot.status == "warning"
+
+
+def test_recommendations_are_sorted_by_priority():
+    snapshot = SituationSnapshot()
+    snapshot.add_recommendation(Recommendation("a", "observe", "later", priority=50))
+    snapshot.add_recommendation(Recommendation("b", "review", "first", priority=10))
+    assert [item.source for item in snapshot.recommendations] == ["b", "a"]
+
+
+def test_recommendations_are_advisory_by_default():
+    recommendation = Recommendation("azazel", "maintain shield", "suspicious scan")
+    assert recommendation.advisory_only is True

--- a/tests/test_situation_render.py
+++ b/tests/test_situation_render.py
@@ -1,0 +1,52 @@
+from babbly.core.render import render_recommendation_ja, render_situation_ja
+from babbly.core.situation import Observation, Recommendation, SituationSnapshot
+from babbly.nlu.japanese import IntentResolver
+
+
+def test_situation_report_intent():
+    resolver = IntentResolver()
+    assert resolver.resolve("現在の状況を報告して").name == "situation.report"
+    assert resolver.resolve("状況を教えて").name == "situation.report"
+
+
+def test_recommendation_explain_intent():
+    resolver = IntentResolver()
+    assert resolver.resolve("推奨を説明して").name == "recommendation.explain"
+    assert resolver.resolve("どうすればいい").name == "recommendation.explain"
+
+
+def test_render_situation_prioritizes_warning_and_recommendation():
+    snapshot = SituationSnapshot()
+    snapshot.set_system_state("azazel", "online")
+    snapshot.add_observation(Observation(source="azazel", category="state", summary="Edge is online", severity="info"))
+    snapshot.add_observation(Observation(source="azazel", category="alert", summary="探索通信を検出", severity="warning"))
+    snapshot.add_recommendation(Recommendation(source="azazel", action="Shield維持", reason="探索通信を継続観測するため", priority=1))
+
+    text = render_situation_ja(snapshot)
+    assert "警戒" in text
+    assert "探索通信を検出" in text
+    assert "Shield維持" in text
+
+
+def test_render_recommendation_is_explicitly_advisory():
+    snapshot = SituationSnapshot()
+    snapshot.add_recommendation(
+        Recommendation(
+            source="azazel",
+            action="Shield維持",
+            reason="探索通信を継続観測するため",
+            priority=1,
+            confidence=0.92,
+            advisory_only=True,
+        )
+    )
+    text = render_recommendation_ja(snapshot)
+    assert "Shield維持" in text
+    assert "92%" in text
+    assert "自動実行はしません" in text
+
+
+def test_empty_snapshot_has_safe_report():
+    snapshot = SituationSnapshot()
+    assert "報告可能な観測はありません" in render_situation_ja(snapshot)
+    assert "提示できる推奨はありません" in render_recommendation_ja(snapshot)


### PR DESCRIPTION
## Summary

This is a stacked follow-up to PR #7. It keeps Babbly generic while adding reusable situational awareness, operator-facing speech, and a bounded read-only integration with the real Azazel-Edge status contract.

## What changed

- added generic `Observation`, `Recommendation`, and `SituationSnapshot` models
- added `SituationEngine` aggregation with adapter failure isolation
- added a read-only/advisory `BabblyAdapter` contract
- added non-executing `situation.report` and `recommendation.explain` Japanese intents
- added concise Japanese spoken rendering for situation and top recommendation
- added a real `AzazelEdgeStatusProvider` that performs GET-only `/api/state` reads
- consumes the existing additive `status_view` emitted by Azazel-Edge from the Azazel-Fabric `StatusView` contract
- does not import or depend on the `azazel-fabric` Python package; Babbly consumes the JSON wire contract
- maps `posture`, `headline`, `reasons`, `health`, `current_action`, `next_actions`, `operator_wording`, `trace_id`, `mode`, and `evidence_ids` into Babbly's generic situation model
- treats `current_action` only as an observation of what Edge already decided; it is never replayed as a Babbly request
- preserves current Edge `operator_wording` as spoken advisory fallback because Edge currently carries its native snapshot recommendation there while `next_actions` is empty
- uses canonical `X-AZAZEL-TOKEN` auth, supported by current Edge alongside `X-Auth-Token`
- adds bounded HTTP timeout, 1 MiB default response cap, no retries, and a short monotonic TTL cache to avoid duplicate `/api/state` reads in one collection
- token material comes from an environment variable or protected token file, not a committed YAML secret
- integration defaults to disabled so standalone Babbly behavior is unchanged
- native Edge fields are a compatibility fallback only when `status_view` is absent
- added contract/transport tests and kept CI running the complete `tests/` directory
- fixed the stale vocabulary expectation that had caused repeated CI failures

## Contract source verified before implementation

The implementation was matched against the current repositories rather than a hypothetical API:

- Azazel-Fabric `StatusView` is the shared read model (`posture`, `headline`, `reasons`, `operator_wording`, `current_action`, `next_actions`, `health`, `evidence_ids`, `product_view`).
- Azazel-Edge already emits `ui_status_view.json` alongside its native snapshot and exposes it additively as `/api/state.status_view`.
- Current Edge auth accepts `X-AZAZEL-TOKEN`, `X-Auth-Token`, or query token; Babbly uses the canonical header.
- Babbly deliberately does not use `/api/state/stream` SSE; on-demand status reads are bounded and cached locally.

## Safety / authority boundary

This PR adds no Azazel write endpoint, autonomous response, arbitrary shell authority, or action adapter. Situation reporting and recommendation explanation remain read-only. Any future write path must be a separate explicit request/approval contract and must not bypass Azazel-Edge deterministic authority.

## CI

The earlier recurring CI failure was a stale vocabulary test expectation and is fixed. The workflow now executes the complete `tests/` directory so newly added safety/transport tests cannot be omitted accidentally. The first workflow run containing the new transport/factory completed its core-test and benchmark-compile steps successfully; the final head is rechecked after this documentation update.

## Stack order

1. PR #7 — offline ASR + deterministic intent foundation
2. this PR — situation model + operator speech + real read-only Azazel-Edge status transport

## Next

Run the integration against the Pi 5 / Edge reference deployment, then implement low-cost wake-word/KWS separation and collect reproducible Vosk vs faster-whisper performance measurements.