### PR TITLE
Add Raspberry Pi runtime benchmark capture

### DIFF
--- a/babbly/benchmark/__init__.py
+++ b/babbly/benchmark/__init__.py
@@ -1,0 +1,3 @@
+from .runtime import RuntimeSample, profile_command, summarize_samples
+
+__all__ = ["RuntimeSample", "profile_command", "summarize_samples"]

--- a/babbly/benchmark/runtime.py
+++ b/babbly/benchmark/runtime.py
@@ -1,0 +1,363 @@
+from __future__ import annotations
+
+import json
+import math
+import os
+import platform
+import signal
+import subprocess
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from statistics import mean
+from typing import Iterable, Mapping, Optional, Sequence
+
+
+@dataclass(frozen=True)
+class RuntimeSample:
+    elapsed_sec: float
+    process_cpu_percent: Optional[float]
+    system_cpu_percent: Optional[float]
+    rss_bytes: Optional[int]
+    temperature_c: Optional[float]
+
+
+def _read_text(path: Path) -> Optional[str]:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+
+
+def _parse_proc_stat_line(text: str) -> tuple[int, int, int]:
+    """Return (ppid, utime_ticks, stime_ticks) from /proc/<pid>/stat."""
+    end = text.rfind(")")
+    if end < 0:
+        raise ValueError("invalid proc stat")
+    fields = text[end + 2 :].split()
+    if len(fields) < 13:
+        raise ValueError("short proc stat")
+    return int(fields[1]), int(fields[11]), int(fields[12])
+
+
+def process_tree_pids(root_pid: int, proc_root: Path = Path("/proc")) -> set[int]:
+    parent_by_pid: dict[int, int] = {}
+    try:
+        entries = list(proc_root.iterdir())
+    except OSError:
+        return {root_pid}
+
+    for entry in entries:
+        if not entry.name.isdigit():
+            continue
+        text = _read_text(entry / "stat")
+        if not text:
+            continue
+        try:
+            ppid, _, _ = _parse_proc_stat_line(text)
+        except (TypeError, ValueError):
+            continue
+        parent_by_pid[int(entry.name)] = ppid
+
+    selected = {root_pid}
+    changed = True
+    while changed:
+        changed = False
+        for pid, ppid in parent_by_pid.items():
+            if pid not in selected and ppid in selected:
+                selected.add(pid)
+                changed = True
+    return selected
+
+
+def read_process_ticks(root_pid: int, proc_root: Path = Path("/proc")) -> Optional[int]:
+    total = 0
+    found = False
+    for pid in process_tree_pids(root_pid, proc_root):
+        text = _read_text(proc_root / str(pid) / "stat")
+        if not text:
+            continue
+        try:
+            _, utime, stime = _parse_proc_stat_line(text)
+        except (TypeError, ValueError):
+            continue
+        total += utime + stime
+        found = True
+    return total if found else None
+
+
+def read_process_rss_bytes(root_pid: int, proc_root: Path = Path("/proc")) -> Optional[int]:
+    total_kib = 0
+    found = False
+    for pid in process_tree_pids(root_pid, proc_root):
+        text = _read_text(proc_root / str(pid) / "status")
+        if not text:
+            continue
+        for line in text.splitlines():
+            if not line.startswith("VmRSS:"):
+                continue
+            parts = line.split()
+            if len(parts) >= 2:
+                try:
+                    total_kib += int(parts[1])
+                    found = True
+                except ValueError:
+                    pass
+            break
+    return total_kib * 1024 if found else None
+
+
+def read_system_cpu(proc_stat: Path = Path("/proc/stat")) -> Optional[tuple[int, int]]:
+    text = _read_text(proc_stat)
+    if not text:
+        return None
+    first = text.splitlines()[0].split()
+    if not first or first[0] != "cpu":
+        return None
+    try:
+        values = [int(value) for value in first[1:]]
+    except ValueError:
+        return None
+    if len(values) < 4:
+        return None
+    idle = values[3] + (values[4] if len(values) > 4 else 0)
+    total = sum(values)
+    return idle, total
+
+
+def _temperature_value(path: Path) -> Optional[float]:
+    text = _read_text(path)
+    if not text:
+        return None
+    try:
+        value = float(text.strip())
+    except ValueError:
+        return None
+    if abs(value) > 1000:
+        value /= 1000.0
+    if -20.0 <= value <= 150.0:
+        return value
+    return None
+
+
+def read_temperature_c(sys_root: Path = Path("/sys")) -> Optional[float]:
+    candidates = [sys_root / "class/thermal/thermal_zone0/temp"]
+    hwmon = sys_root / "class/hwmon"
+    try:
+        for directory in hwmon.glob("hwmon*"):
+            candidates.extend(sorted(directory.glob("temp*_input")))
+    except OSError:
+        pass
+    for path in candidates:
+        value = _temperature_value(path)
+        if value is not None:
+            return value
+    return None
+
+
+def _safe_mean(values: Iterable[Optional[float]]) -> Optional[float]:
+    present = [float(value) for value in values if value is not None and math.isfinite(float(value))]
+    return mean(present) if present else None
+
+
+def _safe_max(values: Iterable[Optional[float]]) -> Optional[float]:
+    present = [float(value) for value in values if value is not None and math.isfinite(float(value))]
+    return max(present) if present else None
+
+
+def summarize_samples(samples: Sequence[RuntimeSample]) -> dict[str, object]:
+    return {
+        "sample_count": len(samples),
+        "process_cpu_percent_mean": _safe_mean(sample.process_cpu_percent for sample in samples),
+        "process_cpu_percent_peak": _safe_max(sample.process_cpu_percent for sample in samples),
+        "system_cpu_percent_mean": _safe_mean(sample.system_cpu_percent for sample in samples),
+        "system_cpu_percent_peak": _safe_max(sample.system_cpu_percent for sample in samples),
+        "rss_bytes_mean": _safe_mean(
+            float(sample.rss_bytes) if sample.rss_bytes is not None else None for sample in samples
+        ),
+        "rss_bytes_peak": (
+            int(value)
+            if (value := _safe_max(
+                float(sample.rss_bytes) if sample.rss_bytes is not None else None for sample in samples
+            ))
+            is not None
+            else None
+        ),
+        "temperature_c_mean": _safe_mean(sample.temperature_c for sample in samples),
+        "temperature_c_peak": _safe_max(sample.temperature_c for sample in samples),
+    }
+
+
+def machine_info() -> dict[str, object]:
+    model = None
+    for path in (Path("/proc/device-tree/model"), Path("/sys/firmware/devicetree/base/model")):
+        text = _read_text(path)
+        if text:
+            model = text.replace("\x00", "").strip()
+            break
+    if not model:
+        cpuinfo = _read_text(Path("/proc/cpuinfo")) or ""
+        for line in cpuinfo.splitlines():
+            if line.lower().startswith("model name") or line.lower().startswith("model\t"):
+                model = line.split(":", 1)[-1].strip()
+                break
+    return {
+        "hostname": platform.node(),
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "processor": platform.processor() or None,
+        "model": model,
+        "python": platform.python_version(),
+        "cpu_count": os.cpu_count(),
+    }
+
+
+class RuntimeSampler:
+    def __init__(self, pid: int) -> None:
+        self.pid = int(pid)
+        self.clock_ticks = int(os.sysconf("SC_CLK_TCK"))
+        self.started = time.monotonic()
+        self._previous_time: Optional[float] = None
+        self._previous_ticks: Optional[int] = None
+        self._previous_system: Optional[tuple[int, int]] = None
+
+    def sample(self) -> RuntimeSample:
+        now = time.monotonic()
+        ticks = read_process_ticks(self.pid)
+        system = read_system_cpu()
+        process_cpu = None
+        system_cpu = None
+
+        if self._previous_time is not None and ticks is not None and self._previous_ticks is not None:
+            elapsed = now - self._previous_time
+            if elapsed > 0:
+                process_cpu = max(0.0, (ticks - self._previous_ticks) / self.clock_ticks / elapsed * 100.0)
+
+        if system is not None and self._previous_system is not None:
+            idle_delta = system[0] - self._previous_system[0]
+            total_delta = system[1] - self._previous_system[1]
+            if total_delta > 0:
+                system_cpu = max(0.0, min(100.0, (total_delta - idle_delta) / total_delta * 100.0))
+
+        self._previous_time = now
+        self._previous_ticks = ticks
+        self._previous_system = system
+
+        return RuntimeSample(
+            elapsed_sec=now - self.started,
+            process_cpu_percent=process_cpu,
+            system_cpu_percent=system_cpu,
+            rss_bytes=read_process_rss_bytes(self.pid),
+            temperature_c=read_temperature_c(),
+        )
+
+
+def _terminate_process_group(process: subprocess.Popen, grace_sec: float = 3.0) -> None:
+    if process.poll() is not None:
+        return
+    try:
+        os.killpg(process.pid, signal.SIGINT)
+    except (OSError, ProcessLookupError):
+        return
+    try:
+        process.wait(timeout=max(0.1, grace_sec))
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+        process.wait(timeout=1.0)
+        return
+    except (OSError, ProcessLookupError, subprocess.TimeoutExpired):
+        pass
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except (OSError, ProcessLookupError):
+        pass
+
+
+def _load_evaluation(path: Optional[str]) -> Optional[Mapping[str, object]]:
+    if not path:
+        return None
+    with open(path, "r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, Mapping):
+        raise ValueError("evaluation JSON must be an object")
+    return payload
+
+
+def profile_command(
+    command: Sequence[str],
+    *,
+    duration_sec: Optional[float] = None,
+    sample_interval_sec: float = 0.5,
+    stop_grace_sec: float = 3.0,
+    label: str = "benchmark",
+    backend_type: Optional[str] = None,
+    backend: Optional[str] = None,
+    model: Optional[str] = None,
+    evaluation_json: Optional[str] = None,
+) -> dict[str, object]:
+    if not command:
+        raise ValueError("command is required")
+    if duration_sec is not None and duration_sec <= 0:
+        raise ValueError("duration_sec must be positive")
+    if sample_interval_sec <= 0:
+        raise ValueError("sample_interval_sec must be positive")
+
+    started_wall = time.time()
+    started_monotonic = time.monotonic()
+    process = subprocess.Popen(list(command), start_new_session=True)
+    sampler = RuntimeSampler(process.pid)
+    samples: list[RuntimeSample] = []
+    stopped_by_duration = False
+
+    try:
+        while True:
+            samples.append(sampler.sample())
+            if process.poll() is not None:
+                break
+            elapsed = time.monotonic() - started_monotonic
+            if duration_sec is not None and elapsed >= duration_sec:
+                stopped_by_duration = True
+                _terminate_process_group(process, stop_grace_sec)
+                break
+            time.sleep(sample_interval_sec)
+    except KeyboardInterrupt:
+        _terminate_process_group(process, stop_grace_sec)
+        raise
+
+    if process.poll() is None:
+        process.wait()
+    ended_monotonic = time.monotonic()
+
+    result: dict[str, object] = {
+        "schema_version": "babbly.runtime-benchmark.v1",
+        "label": label,
+        "backend_type": backend_type,
+        "backend": backend,
+        "model": model,
+        "command": list(command),
+        "started_at_epoch": started_wall,
+        "duration_sec": ended_monotonic - started_monotonic,
+        "configured_duration_sec": duration_sec,
+        "sample_interval_sec": sample_interval_sec,
+        "stopped_by_duration": stopped_by_duration,
+        "exit_code": process.returncode,
+        "status": "completed_window" if stopped_by_duration else ("ok" if process.returncode == 0 else "error"),
+        "machine": machine_info(),
+        "summary": summarize_samples(samples),
+        "samples": [asdict(sample) for sample in samples],
+    }
+    evaluation = _load_evaluation(evaluation_json)
+    if evaluation is not None:
+        result["evaluation"] = dict(evaluation)
+    return result
+
+
+def write_json_atomic(path: str | Path, payload: Mapping[str, object]) -> None:
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_name(destination.name + ".tmp")
+    temporary.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    temporary.replace(destination)

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -46,7 +46,7 @@ The first benchmark intentionally emphasizes operational behavior over transcrip
 - false-execution rate
 - mean recognition latency
 
-For the Pi 5 hardware study, also record externally:
+For the Pi 5 hardware study, also record:
 
 - peak RSS / memory
 - average and peak CPU utilization
@@ -54,7 +54,9 @@ For the Pi 5 hardware study, also record externally:
 - model load time
 - idle power if available
 
-The preferred backend is not automatically the one with the lowest character error rate. Babbly should prioritize high intent accuracy, zero or near-zero false execution, acceptable clarification rate, and field-usable latency.
+`tools/capture_runtime_benchmark.py` now records CPU, process-tree RSS, temperature, machine metadata, duration, and raw samples in one JSON file. It can also embed machine-readable output from the ASR or wake evaluator. See [`docs/pi-runtime-benchmark.md`](../docs/pi-runtime-benchmark.md).
+
+The preferred backend is not automatically the one with the lowest character error rate. Babbly should prioritize high intent accuracy, zero or near-zero false execution, acceptable clarification rate, and field-usable latency while keeping idle/runtime cost acceptable on the target Pi.
 
 ## Safety
 

--- a/docs/pi-runtime-benchmark.md
+++ b/docs/pi-runtime-benchmark.md
@@ -1,0 +1,95 @@
+# Raspberry Pi Runtime Benchmark Capture
+
+`tools/capture_runtime_benchmark.py` profiles a Babbly, ASR, or wake/KWS process with standard-library-only runtime instrumentation. It is designed for Raspberry Pi 5 field measurements but degrades safely on other Linux hosts.
+
+## What it records
+
+Each JSON result contains:
+
+- benchmark label and backend metadata
+- exact child command
+- machine / architecture / Python metadata
+- wall-clock duration and exit status
+- mean and peak process-tree CPU utilization
+- mean and peak system CPU utilization
+- mean and peak process-tree RSS
+- mean and peak temperature when Linux exposes a thermal sensor
+- raw timestamped samples
+- optional embedded ASR or Wake evaluation JSON
+
+The process metrics include descendants, so a launcher that creates worker processes is measured as one benchmark workload.
+
+## Fixed-window idle profile
+
+Use a fixed window to compare the cost of an always-on wake implementation:
+
+```bash
+python tools/capture_runtime_benchmark.py \
+  --output results/wake-asr-idle.json \
+  --label wake-asr-idle \
+  --backend-type wake \
+  --backend asr \
+  --duration 60 \
+  -- python babbly_ja.py
+```
+
+When `--duration` expires, the profiler sends SIGINT to the child process group, waits for the configured grace interval, then escalates to SIGTERM/SIGKILL only if necessary. A deliberate fixed-window stop is reported as `status=completed_window`, not as a benchmark failure.
+
+For sherpa-onnx, configure `WAKE_BACKEND: sherpa-onnx` and provision the local model first, then run the same command with a different label/backend.
+
+## Command-ASR profile
+
+A complete command that exits on its own can be profiled without `--duration`:
+
+```bash
+python tools/capture_runtime_benchmark.py \
+  --output results/asr-whisper.json \
+  --label asr-whisper-small \
+  --backend-type asr \
+  --backend faster-whisper \
+  --model small \
+  -- python your_backend_benchmark.py
+```
+
+## Combine quality and runtime evidence
+
+The existing evaluators can emit machine-readable JSON:
+
+```bash
+python tools/evaluate_wake_results.py results/wake-events.json --json > results/wake-eval.json
+python tools/evaluate_asr_results.py results/asr-events.json --json > results/asr-eval.json
+```
+
+Embed either result in the runtime capture:
+
+```bash
+python tools/capture_runtime_benchmark.py \
+  --output results/wake-sherpa-combined.json \
+  --label wake-sherpa \
+  --backend-type wake \
+  --backend sherpa-onnx \
+  --evaluation-json results/wake-eval.json \
+  --duration 60 \
+  -- python babbly_ja.py
+```
+
+This keeps FAR/FRR or intent accuracy next to CPU, RSS, and temperature evidence instead of maintaining two unrelated records.
+
+## Recommended Pi 5 matrix
+
+Run the same hardware, microphone, room, power supply, cooling setup, sample interval, and corpus for each candidate.
+
+| Layer | Candidate | Key quality metrics | Key runtime metrics |
+|---|---|---|---|
+| Wake | ASR compatibility gate | FAR, FRR, trigger latency | idle CPU/RSS/temp |
+| Wake | sherpa-onnx KWS | FAR, FRR, trigger latency | idle CPU/RSS/temp |
+| Command ASR | Vosk | intent accuracy, false execution, latency | CPU/RSS/temp |
+| Command ASR | faster-whisper | intent accuracy, false execution, latency | CPU/RSS/temp |
+
+Use `DRY_RUN: true` for all voice tuning and benchmark sessions that exercise operational intents.
+
+## Interpretation
+
+`process_cpu_percent` is process-tree CPU consumption where approximately 100% represents one fully utilized logical CPU; multi-threaded workloads may exceed 100%. `system_cpu_percent` is whole-system utilization bounded to 0–100%.
+
+Temperature is best-effort. The profiler checks the standard Raspberry Pi thermal zone first and then common hwmon sensors. Missing temperature data remains `null` and does not invalidate other measurements.

--- a/tests/test_runtime_benchmark.py
+++ b/tests/test_runtime_benchmark.py
@@ -1,0 +1,83 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from babbly.benchmark.runtime import (
+    RuntimeSample,
+    _parse_proc_stat_line,
+    process_tree_pids,
+    read_process_rss_bytes,
+    read_process_ticks,
+    summarize_samples,
+    write_json_atomic,
+)
+
+
+def _stat(pid, ppid, utime, stime, comm="python worker"):
+    # fields after comm start at proc field 3 (state). utime/stime are fields 14/15.
+    tail = [
+        "S",
+        str(ppid),
+        "0",
+        "0",
+        "0",
+        "0",
+        "0",
+        "0",
+        "0",
+        "0",
+        "0",
+        str(utime),
+        str(stime),
+        "0",
+        "0",
+        "0",
+    ]
+    return f"{pid} ({comm}) " + " ".join(tail)
+
+
+def _write_proc(proc_root: Path, pid: int, ppid: int, utime: int, stime: int, rss_kib: int):
+    directory = proc_root / str(pid)
+    directory.mkdir(parents=True)
+    (directory / "stat").write_text(_stat(pid, ppid, utime, stime), encoding="utf-8")
+    (directory / "status").write_text(f"Name:\ttest\nVmRSS:\t{rss_kib} kB\n", encoding="utf-8")
+
+
+def test_parse_proc_stat_handles_spaces_in_comm():
+    assert _parse_proc_stat_line(_stat(10, 3, 20, 5, "python child worker")) == (3, 20, 5)
+
+
+def test_process_tree_and_metrics_include_descendants(tmp_path):
+    proc = tmp_path / "proc"
+    proc.mkdir()
+    _write_proc(proc, 100, 1, 10, 5, 1024)
+    _write_proc(proc, 101, 100, 20, 7, 2048)
+    _write_proc(proc, 102, 101, 3, 2, 512)
+    _write_proc(proc, 200, 1, 99, 99, 9999)
+
+    assert process_tree_pids(100, proc) == {100, 101, 102}
+    assert read_process_ticks(100, proc) == 47
+    assert read_process_rss_bytes(100, proc) == (1024 + 2048 + 512) * 1024
+
+
+def test_summarize_samples_ignores_missing_values():
+    summary = summarize_samples(
+        [
+            RuntimeSample(0.0, None, None, 10, None),
+            RuntimeSample(0.5, 25.0, 50.0, 30, 60.0),
+            RuntimeSample(1.0, 75.0, 70.0, 20, 64.0),
+        ]
+    )
+    assert summary["sample_count"] == 3
+    assert summary["process_cpu_percent_mean"] == pytest.approx(50.0)
+    assert summary["process_cpu_percent_peak"] == pytest.approx(75.0)
+    assert summary["rss_bytes_peak"] == 30
+    assert summary["temperature_c_peak"] == pytest.approx(64.0)
+
+
+def test_write_json_atomic_creates_parent_and_valid_json(tmp_path):
+    output = tmp_path / "nested" / "result.json"
+    write_json_atomic(output, {"schema_version": "test", "ok": True})
+    assert json.loads(output.read_text(encoding="utf-8")) == {"schema_version": "test", "ok": True}
+    assert not (output.parent / "result.json.tmp").exists()

--- a/tools/capture_runtime_benchmark.py
+++ b/tools/capture_runtime_benchmark.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from babbly.benchmark.runtime import profile_command, write_json_atomic
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Profile a Babbly/ASR/KWS command and emit Pi-friendly runtime metrics as JSON"
+    )
+    parser.add_argument("--output", required=True, help="Destination JSON path")
+    parser.add_argument("--label", default="benchmark", help="Human-readable benchmark label")
+    parser.add_argument("--backend-type", choices=("asr", "wake", "other"), default="other")
+    parser.add_argument("--backend", help="Backend name, for example vosk, faster-whisper, sherpa-onnx")
+    parser.add_argument("--model", help="Model name/path label")
+    parser.add_argument(
+        "--duration",
+        type=float,
+        help="Optional fixed profiling window. The child process is stopped when the window expires.",
+    )
+    parser.add_argument("--sample-interval", type=float, default=0.5)
+    parser.add_argument("--stop-grace", type=float, default=3.0)
+    parser.add_argument(
+        "--evaluation-json",
+        help="Optional JSON object from evaluate_asr_results.py/evaluate_wake_results.py to embed",
+    )
+    parser.add_argument("command", nargs=argparse.REMAINDER, help="Command after --")
+    args = parser.parse_args()
+
+    command = list(args.command)
+    if command and command[0] == "--":
+        command = command[1:]
+    if not command:
+        parser.error("a command is required after --")
+
+    try:
+        payload = profile_command(
+            command,
+            duration_sec=args.duration,
+            sample_interval_sec=args.sample_interval,
+            stop_grace_sec=args.stop_grace,
+            label=args.label,
+            backend_type=args.backend_type,
+            backend=args.backend,
+            model=args.model,
+            evaluation_json=args.evaluation_json,
+        )
+        write_json_atomic(args.output, payload)
+    except KeyboardInterrupt:
+        return 130
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"benchmark capture failed: {exc}", file=sys.stderr)
+        return 2
+
+    summary = payload["summary"]
+    print(f"wrote: {args.output}")
+    print(f"status: {payload['status']} duration={payload['duration_sec']:.2f}s")
+    if summary.get("process_cpu_percent_mean") is not None:
+        print(
+            "process cpu: "
+            f"mean={summary['process_cpu_percent_mean']:.1f}% "
+            f"peak={summary['process_cpu_percent_peak']:.1f}%"
+        )
+    if summary.get("rss_bytes_peak") is not None:
+        print(f"peak rss: {summary['rss_bytes_peak'] / (1024 * 1024):.1f} MiB")
+    if summary.get("temperature_c_peak") is not None:
+        print(f"peak temperature: {summary['temperature_c_peak']:.1f} C")
+    return 0 if payload["status"] in {"ok", "completed_window"} else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a Raspberry Pi-oriented runtime benchmark capture path for Babbly's wake/KWS and command-ASR candidates.

## What changed

- added `babbly.benchmark.runtime` with standard-library-only Linux runtime instrumentation
- profiles a child process and all descendants as one workload
- records mean/peak process-tree CPU, whole-system CPU, process-tree RSS, and device temperature
- records raw timestamped samples plus machine/platform/Python metadata
- supports fixed-duration profiling windows for always-on wake/KWS idle-cost measurement
- fixed-window shutdown uses SIGINT -> grace -> SIGTERM/SIGKILL and reports `completed_window` rather than false failure
- added `tools/capture_runtime_benchmark.py` CLI
- supports backend type/name/model labels for Vosk, faster-whisper, sherpa-onnx, etc.
- can embed machine-readable output from `evaluate_asr_results.py` or `evaluate_wake_results.py` so quality and runtime evidence live in one JSON artifact
- temperature collection is best-effort and fails soft to `null` outside supported Linux thermal surfaces
- added unit tests for `/proc` parsing, descendant aggregation, summaries, and atomic JSON writes
- documented Pi 5 benchmark workflow and linked it from `benchmarks/README.md`

## Example

```bash
python tools/capture_runtime_benchmark.py \
  --output results/wake-sherpa.json \
  --label wake-sherpa \
  --backend-type wake \
  --backend sherpa-onnx \
  --duration 60 \
  -- python babbly_ja.py
```

## Safety

This is measurement-only tooling. It does not alter intent authority or execution policy. Voice tuning should continue with `DRY_RUN: true`.

## CI

The branch passed the hardened workflow: Python source compilation and the complete `tests/` directory both succeeded.