### PR TITLE
Add profile-driven agents and M.I.O for Azazel-Edge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,21 +6,42 @@
 
 **Babbly** is a penetration testing support tool featuring **Artificial Incompetence**. Instead of relying on cloud AI, it achieves intuitive dialogue-based operation through natural language processing and voice recognition. Supporting eyes-free and hands-free operation, security tests can be efficiently performed alongside other tasks since they can be executed through voice commands alone without checking the screen. With its human-like conversational interface, it's easy for beginners to use and offers high flexibility.
 
-The current next-generation work is evolving Babbly into a reusable **offline voice-agent foundation**. The migration keeps the original deterministic/SOP model while adding pluggable offline ASR, Japanese normalization, domain vocabulary packs, confidence-aware intent routing, explicit clarification, and a dry-run validation mode. See [`docs/offline-asr.md`](docs/offline-asr.md).
+The current next-generation work is evolving Babbly into a reusable **offline voice-agent foundation**. The migration keeps the original deterministic/SOP model while adding pluggable offline ASR, Japanese normalization, domain vocabulary packs, confidence-aware intent routing, explicit clarification, profile-driven agent identity/persona, and a dry-run validation mode. See [`docs/offline-asr.md`](docs/offline-asr.md) and [`docs/agent-profiles.md`](docs/agent-profiles.md).
 
 「**Babbly**」は**人工無能**（**Artificial Incompetence**）を特徴とするペネトレーションテスト支援ツールです。クラウドAIに依存せず、自然言語処理と音声認識により直感的な対話型操作を実現します。アイズフリー・ハンズフリーに対応し、音声指示だけでテストを実行できるため、画面確認なしで他の作業と並行して効率的なセキュリティテストが可能です。
 
-現在は次世代化として、Babblyを再利用可能な**オフライン音声エージェント基盤**へ進化させています。従来の決定論的なSOPモデルを維持しつつ、差し替え可能なオフラインASR、日本語正規化、ドメイン語彙、信頼度ベースのIntent判定、明示的な聞き返し、DRY RUN検証を追加する方針です。詳細は [`docs/offline-asr.md`](docs/offline-asr.md) を参照してください。
+現在は次世代化として、Babblyを再利用可能な**オフライン音声エージェント基盤**へ進化させています。従来の決定論的なSOPモデルを維持しつつ、差し替え可能なオフラインASR、日本語正規化、ドメイン語彙、信頼度ベースのIntent判定、明示的な聞き返し、Agent Profile、DRY RUN検証を追加しています。
+
+## Agent profiles
+
+Babbly is the framework; the operator-facing agent can change by environment.
+
+```text
+generic / kali      -> Babbly（バブリー）
+azazel-edge         -> M.I.O（ミオ）
+```
+
+Examples:
+
+```bash
+./run_babbly.sh ja --profile generic
+./run_babbly.sh ja --profile azazel-edge
+BABBLY_PROFILE=azazel-edge ./run_babbly.sh ja
+```
+
+The `azazel-edge` profile selects the M.I.O identity, the `ミオ` wake phrase, a concise tactical persona, Azazel vocabulary, and the existing read-only Azazel-Edge situation adapter. Profiles cannot change execution policy, intent thresholds, DRY_RUN, command registries, or Azazel-Edge decision authority.
+
+See [`docs/agent-profiles.md`](docs/agent-profiles.md).
 
 ## Development workflow
 
-Babbly is developed **MacBook-first**. The reference development host is Apple Silicon macOS; Raspberry Pi is the later deployment/hardware-validation target. Core logic, NLU, policy, adapters, dry-run behavior, and development benchmarks should pass on the Mac before Pi-specific audio/resource validation.
+Babbly is developed **MacBook-first**. The current reference development host is a MacBook Pro with M5 Pro; Raspberry Pi is the later deployment/hardware-validation target. Core logic, NLU, policy, adapters, dry-run behavior, profiles, and development benchmarks should pass on the Mac before Pi-specific audio/resource validation.
 
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
 ./run_babbly.sh test
-./run_babbly.sh ja
+./run_babbly.sh ja --profile generic
 ```
 
 See [`docs/development-macos.md`](docs/development-macos.md) for setup, the Mac-to-Pi promotion gate, and the platform-aware development benchmark flow.

--- a/babbly/ja/config_ja.yaml
+++ b/babbly/ja/config_ja.yaml
@@ -1,12 +1,18 @@
 # config_ja.yaml
-WAKEUP_PHRASE: "プログラム"
+# Runtime identity/personality/environment profile. CLI --profile overrides this,
+# and BABBLY_PROFILE overrides it when CLI is absent.
+PROFILE: "generic"
+
+# Compatibility fallback. Active profiles project their own wake phrase(s) into
+# runtime config before the wake detector is built.
+WAKEUP_PHRASE: "バブリー"
 EXIT_PHRASE: "終了"
 COMMANDS_PATH: "babbly/ja/commands.json"
 TARGETS_PATH: "babbly/ja/targets.json"
 SOP_PATH: "babbly/ja/sop.json"
 
-# Set true while tuning voice recognition. Known commands are resolved and
-# confirmed, but executable actions are suppressed.
+# Set true while tuning voice recognition. Profiles are not allowed to override
+# DRY_RUN or execution authority.
 DRY_RUN: false
 
 # Wake detection is independent from command ASR. "asr" preserves the legacy
@@ -30,13 +36,13 @@ ASR_BACKEND: "vosk"
 ASR_LANGUAGE: "ja"
 MODEL_PATH: "babbly/ja/model"
 
-# Intent routing. Unknown or low-confidence speech fails closed.
+# Intent routing. Unknown or low-confidence speech fails closed. These settings
+# remain outside profiles so personality cannot alter execution policy.
 INTENT_EXECUTE_THRESHOLD: 0.90
 INTENT_CLARIFY_THRESHOLD: 0.60
 DOMAIN_VOCABULARY:
   - core
   - kali
-  - azazel
 
 # faster-whisper settings. WHISPER_MODEL may be a model name when initially
 # provisioning, or a local model directory for fully disconnected operation.
@@ -47,9 +53,8 @@ ASR_SILENCE_SECONDS: 0.8
 ASR_MAX_SECONDS: 12.0
 ASR_RMS_THRESHOLD: 0.012
 
-# Optional read-only Azazel-Edge situation source. Disabled by default so
-# standalone Babbly behavior remains unchanged. When enabled, Babbly only GETs
-# /api/state and prefers the additive Azazel-Fabric status_view contract.
+# Optional read-only Azazel-Edge situation source. The active profile decides
+# whether this source is enabled; connection details stay in base config.
 AZAZEL_EDGE_ENABLED: false
 AZAZEL_EDGE_URL: "http://127.0.0.1:8084"
 AZAZEL_EDGE_TOKEN_ENV: "AZAZEL_EDGE_TOKEN"

--- a/babbly/ja/main_program.py
+++ b/babbly/ja/main_program.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+import argparse
 import logging
 import sys
 
@@ -13,22 +14,30 @@ from babbly.modules.commands_manager import CommandManager
 from babbly.modules.ipaddress_manager import IPAddressManager
 from babbly.modules.network_scanner import NetworkScanner
 from babbly.modules.operation_manager import OperationManager
-from babbly.modules.utils import analyze_text, assist_command_mode, introduce, load_config, select_target
+from babbly.modules.utils import analyze_text, assist_command_mode, load_config, select_target
 from babbly.nlu.japanese import IntentResolver, normalize_japanese
 from babbly.nlu.policy import Decision, IntentPolicy
 from babbly.nlu.vocabulary import build_aliases
+from babbly.profiles import apply_profile_to_config, list_profiles, load_profile, resolve_profile_name
 from babbly.wake import create_wake_detector
 
 
 tts = Japanese_TTS()
 lang_ja = 1
 situation_engine = SituationEngine()
+agent_profile = None
 
 
 def set_situation_engine(engine):
     """Inject read-only situation adapters without coupling the voice loop to Azazel."""
     global situation_engine
     situation_engine = engine
+
+
+def set_agent_profile(profile):
+    """Set identity/persona metadata; this does not grant execution authority."""
+    global agent_profile
+    agent_profile = profile
 
 
 def set_globals(config):
@@ -48,6 +57,23 @@ def set_globals(config):
         execute_threshold=float(config.get("INTENT_EXECUTE_THRESHOLD", 0.90)),
         clarify_threshold=float(config.get("INTENT_CLARIFY_THRESHOLD", 0.60)),
     )
+
+
+def _persona_value(field, fallback):
+    if agent_profile is None:
+        return fallback
+    value = getattr(agent_profile.persona, field, None)
+    return value or fallback
+
+
+def introduce_agent():
+    print("自己紹介をします")
+    if agent_profile is None:
+        tts.say("私はバブリー。ミスターラビットによって開発された人工無能システムです")
+        tts.say("私の役割は、ペネトレーションテストにおいて、あなたをサポートすることです")
+        return
+    for sentence in agent_profile.persona.introduction:
+        tts.say(sentence)
 
 
 def listen_result(asr):
@@ -109,7 +135,7 @@ def wait_for_wakeup(wake_detector, asr):
                 confidence,
             )
             print(f"ウェイクアップ検知: {result.keyword} ({result.backend})")
-            tts.say("はい、ボス")
+            tts.say(_persona_value("acknowledgement", "はい、ボス"))
             listen_for_command(asr)
     except KeyboardInterrupt:
         print("\nCtrl+Cが押されました。プログラムを終了します。")
@@ -125,7 +151,7 @@ def listen_for_command(asr):
 
     try:
         print(f"コマンドを入力してください（終了するには {EXIT_PHRASE} を言ってください）")
-        tts.say("指示をどうぞ")
+        tts.say(_persona_value("command_prompt", "指示をどうぞ"))
 
         while True:
             asr_result = listen_result(asr)
@@ -152,7 +178,7 @@ def listen_for_command(asr):
                     tts.say("終了指示を確認できませんでした")
                     continue
                 print("終了フレーズ認識。処理を終了します。")
-                tts.say("システムを終了します。お疲れ様でした。")
+                tts.say(_persona_value("shutdown_phrase", "システムを終了します。お疲れ様でした。"))
                 raise SystemExit(0)
 
             if intent.name != "unknown" and policy.decision == Decision.CLARIFY:
@@ -165,7 +191,7 @@ def listen_for_command(asr):
                 continue
 
             if intent.name == "system.introduce":
-                introduce(tts, lang_ja)
+                introduce_agent()
                 break
 
             if intent.name == "situation.report":
@@ -240,7 +266,7 @@ def listen_for_command(asr):
                 cmd_mgr.execute_command(cmd_name, ipaddress if cmd_arg else None)
                 break
 
-            tts.say("指示を特定できませんでした。もう一度お願いします")
+            tts.say(_persona_value("unknown_prompt", "指示を特定できませんでした。もう一度お願いします"))
 
         print("再度ウェイクアップフレーズを待機します。")
     except KeyboardInterrupt:
@@ -249,19 +275,51 @@ def listen_for_command(asr):
         raise SystemExit(0)
 
 
-def main():
-    ascii_art = pyfiglet.figlet_format("Babbly", font="dos_rebel")
-    print(ascii_art)
-    logging.info("プログラム開始")
+def _parse_args(argv=None):
+    parser = argparse.ArgumentParser(description="Babbly Japanese offline agent")
+    parser.add_argument(
+        "--profile",
+        help="Agent/environment profile name. Overrides BABBLY_PROFILE and config PROFILE.",
+    )
+    parser.add_argument(
+        "--list-profiles",
+        action="store_true",
+        help="List available local profiles and exit.",
+    )
+    return parser.parse_args(argv)
 
-    config = load_config("babbly/ja/config_ja.yaml")
+
+def main(argv=None):
+    args = _parse_args(argv)
+    base_config = load_config("babbly/ja/config_ja.yaml")
+
+    if args.list_profiles:
+        for name in list_profiles():
+            print(name)
+        return
+
+    profile_name = resolve_profile_name(args.profile, base_config)
+    profile = load_profile(profile_name)
+    config = apply_profile_to_config(base_config, profile)
+    set_agent_profile(profile)
     set_globals(config)
     set_situation_engine(create_situation_engine(config))
+
+    ascii_art = pyfiglet.figlet_format(profile.identity.display_name, font="dos_rebel")
+    print(ascii_art)
+    print(
+        f"profile={profile.id} agent={profile.identity.display_name} "
+        f"wake={', '.join(profile.identity.wake_phrases)} environment={profile.environment.type}"
+    )
+    logging.info("プログラム開始")
 
     asr = create_asr(config)
     wake_detector = create_wake_detector(config, asr, domain_aliases)
     logging.info(
-        "設定読み込み完了 dry_run=%s azazel_edge=%s asr=%s wake=%s",
+        "設定読み込み完了 profile=%s agent=%s persona=%s dry_run=%s azazel_edge=%s asr=%s wake=%s",
+        profile.id,
+        profile.identity.display_name,
+        profile.persona.style,
         DRY_RUN,
         bool(config.get("AZAZEL_EDGE_ENABLED", False)),
         config.get("ASR_BACKEND", "vosk"),
@@ -271,7 +329,7 @@ def main():
     print("＜音声認識開始 - 入力を待機します＞")
     if DRY_RUN:
         print("DRY_RUN is enabled: executable actions will be suppressed")
-    tts.say("人工無能システム、バブリー、起動します。")
+    tts.say(profile.persona.startup_phrase)
     wait_for_wakeup(wake_detector, asr)
 
 

--- a/babbly/profiles/__init__.py
+++ b/babbly/profiles/__init__.py
@@ -1,0 +1,13 @@
+from .model import AgentIdentity, AgentProfile, EnvironmentProfile, PersonaProfile
+from .loader import apply_profile_to_config, list_profiles, load_profile, resolve_profile_name
+
+__all__ = [
+    "AgentIdentity",
+    "AgentProfile",
+    "EnvironmentProfile",
+    "PersonaProfile",
+    "apply_profile_to_config",
+    "list_profiles",
+    "load_profile",
+    "resolve_profile_name",
+]

--- a/babbly/profiles/loader.py
+++ b/babbly/profiles/loader.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import Mapping, Optional
+
+from .model import AgentIdentity, AgentProfile, EnvironmentProfile, PersonaProfile
+
+
+_PROFILE_NAME = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
+_ALLOWED_SITUATION_SOURCES = {"azazel-edge"}
+_DEFAULT_PROFILE_DIR = Path("profiles")
+
+
+def _require_mapping(value, field: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{field} must be an object")
+    return value
+
+
+def _require_text(value, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} must be a non-empty string")
+    return value.strip()
+
+
+def _text_list(value, field: str, *, allow_empty: bool = False) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        raise ValueError(f"{field} must be an array")
+    items = tuple(_require_text(item, field) for item in value)
+    if not items and not allow_empty:
+        raise ValueError(f"{field} must not be empty")
+    return items
+
+
+def _profile_dir(root: Optional[str | Path] = None) -> Path:
+    if root is not None:
+        return Path(root)
+    configured = os.environ.get("BABBLY_PROFILE_DIR")
+    return Path(configured).expanduser() if configured else _DEFAULT_PROFILE_DIR
+
+
+def list_profiles(root: Optional[str | Path] = None) -> tuple[str, ...]:
+    directory = _profile_dir(root)
+    try:
+        names = [path.stem for path in directory.glob("*.json") if path.is_file()]
+    except OSError:
+        return ()
+    return tuple(sorted(name for name in names if _PROFILE_NAME.fullmatch(name)))
+
+
+def resolve_profile_name(
+    cli_value: Optional[str],
+    config: Mapping[str, object],
+    environ: Optional[Mapping[str, str]] = None,
+) -> str:
+    env = os.environ if environ is None else environ
+    value = cli_value or env.get("BABBLY_PROFILE") or config.get("PROFILE") or "generic"
+    name = str(value).strip().lower()
+    if not _PROFILE_NAME.fullmatch(name):
+        raise ValueError(f"invalid profile name: {name!r}")
+    return name
+
+
+def load_profile(name: str, root: Optional[str | Path] = None) -> AgentProfile:
+    normalized = str(name).strip().lower()
+    if not _PROFILE_NAME.fullmatch(normalized):
+        raise ValueError(f"invalid profile name: {normalized!r}")
+
+    path = _profile_dir(root) / f"{normalized}.json"
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(f"profile not found: {normalized}") from exc
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"profile cannot be loaded: {normalized}: {exc}") from exc
+
+    root_obj = _require_mapping(payload, "profile")
+    profile_id = _require_text(root_obj.get("id"), "id").lower()
+    if profile_id != normalized:
+        raise ValueError(f"profile id mismatch: expected {normalized!r}, got {profile_id!r}")
+
+    identity_obj = _require_mapping(root_obj.get("identity"), "identity")
+    identity = AgentIdentity(
+        id=_require_text(identity_obj.get("id"), "identity.id"),
+        display_name=_require_text(identity_obj.get("display_name"), "identity.display_name"),
+        spoken_name=_require_text(identity_obj.get("spoken_name"), "identity.spoken_name"),
+        wake_phrases=_text_list(identity_obj.get("wake_phrases"), "identity.wake_phrases"),
+        language=_require_text(identity_obj.get("language", "ja"), "identity.language"),
+    )
+
+    persona_obj = _require_mapping(root_obj.get("persona"), "persona")
+    persona = PersonaProfile(
+        tone=_require_text(persona_obj.get("tone"), "persona.tone"),
+        style=_require_text(persona_obj.get("style"), "persona.style"),
+        verbosity=_require_text(persona_obj.get("verbosity"), "persona.verbosity"),
+        startup_phrase=_require_text(persona_obj.get("startup_phrase"), "persona.startup_phrase"),
+        acknowledgement=_require_text(persona_obj.get("acknowledgement"), "persona.acknowledgement"),
+        command_prompt=_require_text(persona_obj.get("command_prompt"), "persona.command_prompt"),
+        unknown_prompt=_require_text(persona_obj.get("unknown_prompt"), "persona.unknown_prompt"),
+        shutdown_phrase=_require_text(persona_obj.get("shutdown_phrase"), "persona.shutdown_phrase"),
+        introduction=_text_list(persona_obj.get("introduction"), "persona.introduction"),
+    )
+
+    environment_obj = _require_mapping(root_obj.get("environment"), "environment")
+    sources = _text_list(
+        environment_obj.get("situation_sources", []),
+        "environment.situation_sources",
+        allow_empty=True,
+    )
+    unknown_sources = sorted(set(sources) - _ALLOWED_SITUATION_SOURCES)
+    if unknown_sources:
+        raise ValueError(f"unsupported situation source(s): {', '.join(unknown_sources)}")
+    environment = EnvironmentProfile(
+        type=_require_text(environment_obj.get("type"), "environment.type"),
+        vocabulary_packs=_text_list(environment_obj.get("vocabulary_packs"), "environment.vocabulary_packs"),
+        situation_sources=sources,
+    )
+
+    return AgentProfile(profile_id, identity, persona, environment)
+
+
+def apply_profile_to_config(
+    config: Mapping[str, object],
+    profile: AgentProfile,
+) -> dict[str, object]:
+    """Project only non-authority profile fields into runtime configuration.
+
+    Profiles may select identity, wake phrases, vocabulary, and read-only
+    situation sources. They cannot modify DRY_RUN, intent thresholds, command
+    registries, action policy, or any execution authority setting.
+    """
+    projected = dict(config)
+    projected["ACTIVE_PROFILE"] = profile.id
+    projected["WAKEUP_PHRASE"] = profile.identity.primary_wake_phrase
+    projected["WAKEUP_PHRASES"] = list(profile.identity.wake_phrases)
+    projected["DOMAIN_VOCABULARY"] = list(profile.environment.vocabulary_packs)
+    projected["AZAZEL_EDGE_ENABLED"] = "azazel-edge" in profile.environment.situation_sources
+    return projected

--- a/babbly/profiles/model.py
+++ b/babbly/profiles/model.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AgentIdentity:
+    id: str
+    display_name: str
+    spoken_name: str
+    wake_phrases: tuple[str, ...]
+    language: str = "ja"
+
+    @property
+    def primary_wake_phrase(self) -> str:
+        return self.wake_phrases[0]
+
+
+@dataclass(frozen=True)
+class PersonaProfile:
+    tone: str
+    style: str
+    verbosity: str
+    startup_phrase: str
+    acknowledgement: str
+    command_prompt: str
+    unknown_prompt: str
+    shutdown_phrase: str
+    introduction: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class EnvironmentProfile:
+    type: str
+    vocabulary_packs: tuple[str, ...]
+    situation_sources: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class AgentProfile:
+    id: str
+    identity: AgentIdentity
+    persona: PersonaProfile
+    environment: EnvironmentProfile

--- a/babbly/wake/asr_backend.py
+++ b/babbly/wake/asr_backend.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
 from babbly.nlu.japanese import normalize_japanese
 from babbly.wake.base import WakeDetector
 from babbly.wake.types import WakeResult
@@ -6,15 +10,21 @@ from babbly.wake.types import WakeResult
 class ASRWakeDetector(WakeDetector):
     """Compatibility wake gate using the configured ASR backend.
 
-    This preserves the existing behavior while allowing the main loop to stop
-    depending on how wake detection is implemented.
+    A profile may expose one or more wake phrases. Matching remains low-authority:
+    a wake hit only opens command listening and never creates an executable intent.
     """
 
-    def __init__(self, asr, phrase: str, aliases=None):
+    def __init__(self, asr, phrases: str | Sequence[str], aliases=None):
         self.asr = asr
-        self.phrase = phrase
         self.aliases = aliases
-        self.expected = normalize_japanese(phrase, aliases)
+        if isinstance(phrases, str):
+            values = (phrases,)
+        else:
+            values = tuple(str(value) for value in phrases)
+        self.phrases = tuple(value.strip() for value in values if value.strip())
+        self.expected = tuple(
+            (phrase, normalize_japanese(phrase, aliases)) for phrase in self.phrases
+        )
 
     def wait(self) -> WakeResult:
         while True:
@@ -22,10 +32,11 @@ class ASRWakeDetector(WakeDetector):
             if result.is_empty:
                 continue
             text = normalize_japanese(result.text, self.aliases)
-            if self.expected and self.expected in text:
-                return WakeResult(
-                    triggered=True,
-                    keyword=self.phrase,
-                    backend=f"asr:{result.backend}",
-                    confidence=result.confidence,
-                )
+            for phrase, expected in self.expected:
+                if expected and expected in text:
+                    return WakeResult(
+                        triggered=True,
+                        keyword=phrase,
+                        backend=f"asr:{result.backend}",
+                        confidence=result.confidence,
+                    )

--- a/babbly/wake/factory.py
+++ b/babbly/wake/factory.py
@@ -4,10 +4,12 @@ from babbly.wake.sherpa_onnx_backend import SherpaOnnxWakeDetector
 
 def create_wake_detector(config, asr, aliases=None):
     backend = str(config.get("WAKE_BACKEND", "asr")).strip().lower()
-    phrase = str(config.get("WAKEUP_PHRASE") or "").strip()
+    phrases = config.get("WAKEUP_PHRASES")
+    if not isinstance(phrases, list) or not phrases:
+        phrases = [str(config.get("WAKEUP_PHRASE") or "").strip()]
 
     if backend in {"asr", "legacy"}:
-        return ASRWakeDetector(asr, phrase, aliases)
+        return ASRWakeDetector(asr, phrases, aliases)
 
     if backend in {"sherpa-onnx", "sherpa", "kws"}:
         return SherpaOnnxWakeDetector(

--- a/docs/agent-profiles.md
+++ b/docs/agent-profiles.md
@@ -1,0 +1,150 @@
+# Agent and environment profiles
+
+Babbly is the offline agent framework. The operator-facing agent identity is selected by profile.
+
+This separates framework identity from the name spoken by the user:
+
+```text
+Babbly Core
+  -> Agent Profile
+      -> identity / wake phrases
+      -> persona / response style
+      -> environment vocabulary
+      -> read-only situation sources
+  -> Intent / Policy / Authority
+```
+
+Profiles deliberately do **not** control execution authority.
+
+## Built-in profiles
+
+### `generic`
+
+- display name: `Babbly`
+- spoken name: `バブリー`
+- wake phrase: `バブリー`
+- persona: friendly, concise operator assistant
+- vocabulary: `core`, `kali`
+- situation source: none
+
+### `kali`
+
+- display name: `Babbly`
+- spoken name: `バブリー`
+- wake phrase: `バブリー`
+- persona: focused operator
+- vocabulary: `core`, `kali`
+- situation source: none
+
+### `azazel-edge`
+
+- display name: `M.I.O`
+- spoken name: `ミオ`
+- wake phrase: `ミオ`
+- persona: calm, tactical, short responses
+- vocabulary: `core`, `azazel`
+- situation source: read-only `azazel-edge`
+
+The Azazel profile does not give M.I.O enforcement authority. It enables only the existing read-only situation adapter. Any future action request path remains separate and must preserve Azazel-Edge's deterministic decision authority.
+
+## Selecting a profile
+
+Mac-first launcher:
+
+```bash
+./run_babbly.sh ja --profile generic
+./run_babbly.sh ja --profile kali
+./run_babbly.sh ja --profile azazel-edge
+```
+
+Environment variable:
+
+```bash
+BABBLY_PROFILE=azazel-edge ./run_babbly.sh ja
+```
+
+Precedence is:
+
+```text
+--profile
+  > BABBLY_PROFILE
+  > PROFILE in config_ja.yaml
+  > generic
+```
+
+List available profiles:
+
+```bash
+python babbly_ja.py --list-profiles
+```
+
+## Local/custom profile directory
+
+Set `BABBLY_PROFILE_DIR` to a local directory containing profile JSON files. Profile names are restricted to safe filename characters, and path traversal is rejected.
+
+```bash
+BABBLY_PROFILE_DIR="$HOME/.config/babbly/profiles" \
+BABBLY_PROFILE=my-agent \
+./run_babbly.sh ja
+```
+
+This allows local persona variants without committing them to the repository.
+
+## Profile schema
+
+```json
+{
+  "id": "azazel-edge",
+  "identity": {
+    "id": "mio",
+    "display_name": "M.I.O",
+    "spoken_name": "ミオ",
+    "wake_phrases": ["ミオ"],
+    "language": "ja"
+  },
+  "persona": {
+    "tone": "calm_tactical",
+    "style": "tactical_concise",
+    "verbosity": "short",
+    "startup_phrase": "ミオ、起動。Azazel-Edge支援を開始します。",
+    "acknowledgement": "はい",
+    "command_prompt": "指示をどうぞ",
+    "unknown_prompt": "指示を特定できません。再度お願いします",
+    "shutdown_phrase": "ミオを終了します。",
+    "introduction": [
+      "ミオです。Azazel-Edgeの状況確認とオペレーター支援を行います",
+      "判断と実行権限はAzazel-Edge側の決定論的ポリシーに従います"
+    ]
+  },
+  "environment": {
+    "type": "azazel-edge",
+    "vocabulary_packs": ["core", "azazel"],
+    "situation_sources": ["azazel-edge"]
+  }
+}
+```
+
+## Authority boundary
+
+Profile projection is intentionally narrow. It may change:
+
+- agent identity
+- wake phrases
+- response/persona wording
+- vocabulary packs
+- approved read-only situation sources
+
+It cannot change:
+
+- `DRY_RUN`
+- intent execute/clarify thresholds
+- command or SOP registries
+- confirmation policy
+- execution authority
+- Azazel-Edge decision authority
+
+Persona therefore changes **how the agent presents itself**, not **what the agent is authorized to do**.
+
+## Wake backends
+
+The ASR-compatible wake backend supports multiple profile wake phrases. For KWS/sherpa-onnx deployments, the selected local keyword model/file still has to contain a compatible keyword. Selecting `azazel-edge` changes the intended wake identity to `ミオ`, but it does not dynamically retrain or download a KWS model.

--- a/docs/development-macos.md
+++ b/docs/development-macos.md
@@ -16,7 +16,7 @@ The development workflow should remain compatible with Apple Silicon Macs genera
 
 1. Implement on the MacBook Pro M5 Pro.
 2. Run compile/unit/core tests on the MacBook.
-3. Exercise normalization, intent, policy, Situation Model, adapters, dry-run behavior, and benchmark tooling locally.
+3. Exercise normalization, intent, policy, Agent Profiles, Situation Model, adapters, dry-run behavior, and benchmark tooling locally.
 4. Commit and push to GitHub; CI runs on both macOS and Linux.
 5. Pull the verified revision to the Raspberry Pi target.
 6. Validate Pi-specific audio devices, KWS/ASR latency, thermal behavior, and resource limits on the Pi.
@@ -41,11 +41,25 @@ Run tests:
 ./run_babbly.sh test
 ```
 
-Run Japanese Babbly:
+List profiles:
 
 ```bash
-./run_babbly.sh ja
+python babbly_ja.py --list-profiles
 ```
+
+Run normal Babbly:
+
+```bash
+./run_babbly.sh ja --profile generic
+```
+
+Run the Azazel-Edge M.I.O profile:
+
+```bash
+./run_babbly.sh ja --profile azazel-edge
+```
+
+For M.I.O, the expected operator-facing identity is `M.I.O`, the spoken/wake name is `ミオ`, the vocabulary is `core + azazel`, and the read-only Azazel-Edge situation source is enabled. Profile selection must not alter DRY_RUN, Intent thresholds, command/SOP registries, or action authority.
 
 During voice/intent development, set `DRY_RUN: true` in `babbly/ja/config_ja.yaml` so operational actions remain suppressed.
 
@@ -60,8 +74,10 @@ python tools/capture_dev_benchmark.py \
   --backend-type asr \
   --backend vosk \
   --duration 30 \
-  -- python babbly_ja.py
+  -- python babbly_ja.py --profile generic
 ```
+
+To benchmark M.I.O's runtime path, append `--profile azazel-edge` to the child command.
 
 On macOS it uses `ps` to aggregate CPU and RSS for the Babbly process tree. The benchmark JSON records macOS machine information via `sysctl`, so M5 Pro measurements can be separated from other Apple Silicon results. It does not invent a temperature value: macOS temperature remains `null` unless a future explicitly supported sensor provider is added.
 
@@ -71,7 +87,7 @@ Move a change to Pi validation only after the Mac/CI layer passes. Pi validation
 
 - physical microphone/speaker behavior
 - ALSA/Pulse/PipeWire/device-specific integration where applicable
-- wake-word false accept/reject behavior on the actual microphone
+- profile wake-word false accept/reject behavior on the actual microphone
 - ASR real-time latency
 - CPU/RSS under the deployment image
 - temperature and throttling

--- a/profiles/azazel-edge.json
+++ b/profiles/azazel-edge.json
@@ -1,0 +1,29 @@
+{
+  "id": "azazel-edge",
+  "identity": {
+    "id": "mio",
+    "display_name": "M.I.O",
+    "spoken_name": "ミオ",
+    "wake_phrases": ["ミオ"],
+    "language": "ja"
+  },
+  "persona": {
+    "tone": "calm_tactical",
+    "style": "tactical_concise",
+    "verbosity": "short",
+    "startup_phrase": "M.I.O、起動。Azazel-Edge支援を開始します。",
+    "acknowledgement": "はい",
+    "command_prompt": "指示をどうぞ",
+    "unknown_prompt": "指示を特定できません。再度お願いします",
+    "shutdown_phrase": "M.I.Oを終了します。",
+    "introduction": [
+      "M.I.Oです。Azazel-Edgeの状況確認とオペレーター支援を行います",
+      "判断と実行権限はAzazel-Edge側の決定論的ポリシーに従います"
+    ]
+  },
+  "environment": {
+    "type": "azazel-edge",
+    "vocabulary_packs": ["core", "azazel"],
+    "situation_sources": ["azazel-edge"]
+  }
+}

--- a/profiles/azazel-edge.json
+++ b/profiles/azazel-edge.json
@@ -11,13 +11,13 @@
     "tone": "calm_tactical",
     "style": "tactical_concise",
     "verbosity": "short",
-    "startup_phrase": "M.I.O、起動。Azazel-Edge支援を開始します。",
+    "startup_phrase": "ミオ、起動。Azazel-Edge支援を開始します。",
     "acknowledgement": "はい",
     "command_prompt": "指示をどうぞ",
     "unknown_prompt": "指示を特定できません。再度お願いします",
-    "shutdown_phrase": "M.I.Oを終了します。",
+    "shutdown_phrase": "ミオを終了します。",
     "introduction": [
-      "M.I.Oです。Azazel-Edgeの状況確認とオペレーター支援を行います",
+      "ミオです。Azazel-Edgeの状況確認とオペレーター支援を行います",
       "判断と実行権限はAzazel-Edge側の決定論的ポリシーに従います"
     ]
   },

--- a/profiles/generic.json
+++ b/profiles/generic.json
@@ -1,0 +1,29 @@
+{
+  "id": "generic",
+  "identity": {
+    "id": "babbly",
+    "display_name": "Babbly",
+    "spoken_name": "バブリー",
+    "wake_phrases": ["バブリー"],
+    "language": "ja"
+  },
+  "persona": {
+    "tone": "friendly",
+    "style": "operator_assistant",
+    "verbosity": "concise",
+    "startup_phrase": "人工無能システム、バブリー、起動します。",
+    "acknowledgement": "はい、ボス",
+    "command_prompt": "指示をどうぞ",
+    "unknown_prompt": "指示を特定できませんでした。もう一度お願いします",
+    "shutdown_phrase": "システムを終了します。お疲れ様でした。",
+    "introduction": [
+      "私はバブリー。ミスターラビットによって開発された人工無能システムです",
+      "私の役割は、ペネトレーションテストにおいて、あなたをサポートすることです"
+    ]
+  },
+  "environment": {
+    "type": "generic",
+    "vocabulary_packs": ["core", "kali"],
+    "situation_sources": []
+  }
+}

--- a/profiles/kali.json
+++ b/profiles/kali.json
@@ -1,0 +1,29 @@
+{
+  "id": "kali",
+  "identity": {
+    "id": "babbly-kali",
+    "display_name": "Babbly",
+    "spoken_name": "バブリー",
+    "wake_phrases": ["バブリー"],
+    "language": "ja"
+  },
+  "persona": {
+    "tone": "focused",
+    "style": "operator",
+    "verbosity": "concise",
+    "startup_phrase": "バブリー、Kaliオペレーターモードで起動します。",
+    "acknowledgement": "了解",
+    "command_prompt": "指示をどうぞ",
+    "unknown_prompt": "指示を特定できませんでした。再度お願いします",
+    "shutdown_phrase": "Kaliオペレーターモードを終了します。",
+    "introduction": [
+      "私はバブリー。Kali環境でオペレーターを支援します",
+      "登録済みの手順とポリシーに従って動作します"
+    ]
+  },
+  "environment": {
+    "type": "kali",
+    "vocabulary_packs": ["core", "kali"],
+    "situation_sources": []
+  }
+}

--- a/run_babbly.sh
+++ b/run_babbly.sh
@@ -22,18 +22,23 @@ fi
 source .venv/bin/activate
 
 MODE="${1:-ja}"
+if [[ $# -gt 0 ]]; then
+  shift
+fi
+
 case "$MODE" in
   ja)
-    exec python babbly_ja.py
+    exec python babbly_ja.py "$@"
     ;;
   en)
-    exec python babbly_en.py
+    exec python babbly_en.py "$@"
     ;;
   test)
-    exec python -m pytest -q tests
+    exec python -m pytest -q tests "$@"
     ;;
   *)
-    echo "Usage: ./run_babbly.sh [ja|en|test]"
+    echo "Usage: ./run_babbly.sh [ja|en|test] [options]"
+    echo "Example: ./run_babbly.sh ja --profile azazel-edge"
     exit 2
     ;;
 esac

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+
+import pytest
+
+from babbly.profiles import apply_profile_to_config, list_profiles, load_profile, resolve_profile_name
+
+
+PROFILE_DIR = Path("profiles")
+
+
+def test_generic_profile_is_babbly():
+    profile = load_profile("generic", PROFILE_DIR)
+    assert profile.identity.display_name == "Babbly"
+    assert profile.identity.spoken_name == "バブリー"
+    assert profile.identity.primary_wake_phrase == "バブリー"
+    assert profile.environment.situation_sources == ()
+
+
+def test_azazel_edge_profile_is_mio_and_read_only_source_enabled():
+    profile = load_profile("azazel-edge", PROFILE_DIR)
+    assert profile.identity.display_name == "M.I.O"
+    assert profile.identity.spoken_name == "ミオ"
+    assert profile.identity.wake_phrases == ("ミオ",)
+    assert profile.persona.style == "tactical_concise"
+    assert profile.environment.vocabulary_packs == ("core", "azazel")
+    assert profile.environment.situation_sources == ("azazel-edge",)
+
+
+def test_profile_projection_cannot_change_authority_settings():
+    base = {
+        "DRY_RUN": True,
+        "INTENT_EXECUTE_THRESHOLD": 0.97,
+        "INTENT_CLARIFY_THRESHOLD": 0.80,
+        "COMMANDS_PATH": "commands.json",
+        "AZAZEL_EDGE_ENABLED": False,
+    }
+    profile = load_profile("azazel-edge", PROFILE_DIR)
+
+    projected = apply_profile_to_config(base, profile)
+
+    assert projected["DRY_RUN"] is True
+    assert projected["INTENT_EXECUTE_THRESHOLD"] == 0.97
+    assert projected["INTENT_CLARIFY_THRESHOLD"] == 0.80
+    assert projected["COMMANDS_PATH"] == "commands.json"
+    assert projected["AZAZEL_EDGE_ENABLED"] is True
+    assert projected["WAKEUP_PHRASE"] == "ミオ"
+    assert projected["WAKEUP_PHRASES"] == ["ミオ"]
+    assert projected["DOMAIN_VOCABULARY"] == ["core", "azazel"]
+
+
+def test_generic_profile_disables_environment_specific_source():
+    projected = apply_profile_to_config(
+        {"AZAZEL_EDGE_ENABLED": True},
+        load_profile("generic", PROFILE_DIR),
+    )
+    assert projected["AZAZEL_EDGE_ENABLED"] is False
+
+
+def test_profile_resolution_precedence():
+    config = {"PROFILE": "generic"}
+    assert resolve_profile_name("azazel-edge", config, {"BABBLY_PROFILE": "kali"}) == "azazel-edge"
+    assert resolve_profile_name(None, config, {"BABBLY_PROFILE": "kali"}) == "kali"
+    assert resolve_profile_name(None, config, {}) == "generic"
+
+
+def test_profile_name_rejects_path_traversal():
+    with pytest.raises(ValueError):
+        load_profile("../secret", PROFILE_DIR)
+
+
+def test_builtin_profiles_are_discoverable():
+    names = list_profiles(PROFILE_DIR)
+    assert "generic" in names
+    assert "kali" in names
+    assert "azazel-edge" in names

--- a/tests/test_wake_gate.py
+++ b/tests/test_wake_gate.py
@@ -32,12 +32,29 @@ def test_asr_wake_detector_is_not_sensitive_to_whitespace():
     assert ASRWakeDetector(asr, "プログラム").wait().triggered is True
 
 
+def test_asr_wake_detector_accepts_profile_phrase_set():
+    asr = FakeASR([ASRResult("ねえ ミオ 状況は", 0.91, "fake")])
+    result = ASRWakeDetector(asr, ["ミオ", "MIO"]).wait()
+    assert result.triggered is True
+    assert result.keyword == "ミオ"
+    assert result.confidence == 0.91
+
+
 def test_factory_defaults_to_legacy_compatible_asr_gate():
     detector = create_wake_detector(
         {"WAKEUP_PHRASE": "プログラム"},
         FakeASR([ASRResult("プログラム", None, "fake")]),
     )
     assert isinstance(detector, ASRWakeDetector)
+
+
+def test_factory_prefers_profile_wake_phrases():
+    detector = create_wake_detector(
+        {"WAKEUP_PHRASE": "fallback", "WAKEUP_PHRASES": ["ミオ"]},
+        FakeASR([ASRResult("ミオ", None, "fake")]),
+    )
+    result = detector.wait()
+    assert result.keyword == "ミオ"
 
 
 def test_unknown_wake_backend_is_rejected():


### PR DESCRIPTION
## Summary

Separates the Babbly framework from the operator-facing agent identity and adds environment-specific Agent Profiles. The first Azazel-Edge profile is **M.I.O（ミオ）**.

## What changed

- added safe `AgentIdentity`, `PersonaProfile`, `EnvironmentProfile`, and `AgentProfile` models
- added JSON profile loader using only the Python standard library
- added built-in profiles: `generic`, `kali`, and `azazel-edge`
- `generic` / `kali` use Babbly（バブリー）
- `azazel-edge` uses M.I.O（ミオ） with wake phrase `ミオ`
- profile persona controls startup, acknowledgement, command prompt, unknown response, shutdown response, introduction, and style metadata
- profile environment selects vocabulary packs and approved read-only situation sources
- Azazel-Edge profile enables the existing read-only Edge situation adapter and `core + azazel` vocabulary
- wake ASR backend now supports one or more profile-defined wake phrases
- added `--profile`, `BABBLY_PROFILE`, `PROFILE` config precedence and `--list-profiles`
- added optional local profile directory through `BABBLY_PROFILE_DIR` with path-traversal-safe profile names
- Mac launcher now passes profile arguments through
- updated MacBook Pro M5 Pro development/test documentation

## Authority boundary

Profiles cannot modify:

- DRY_RUN
- Intent execute/clarify thresholds
- command/SOP registries
- confirmation policy
- execution authority
- Azazel-Edge deterministic decision authority

The M.I.O profile changes identity/persona/environment presentation and enables only the existing read-only situation source.

## Usage

```bash
./run_babbly.sh ja --profile generic
./run_babbly.sh ja --profile azazel-edge
BABBLY_PROFILE=azazel-edge ./run_babbly.sh ja
python babbly_ja.py --list-profiles
```

## CI

Latest branch head passes Python compilation and the complete test suite on both macOS and Ubuntu.