### PR TITLE
Implement canonical operator-intent contract

### DIFF
--- a/babbly/core/operator_intent.py
+++ b/babbly/core/operator_intent.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from enum import Enum
+from typing import Any, Mapping, Optional
+from uuid import uuid4
+
+
+SCHEMA_VERSION = "babbly.operator-intent.v1"
+
+
+class SourceModality(str, Enum):
+    VOICE = "voice"
+    TUI = "tui"
+    WEB = "web"
+    EUD = "eud"
+    TEST = "test"
+
+
+class ClarificationState(str, Enum):
+    NONE = "none"
+    REQUIRED = "required"
+    CONFIRMED = "confirmed"
+    DENIED = "denied"
+
+
+@dataclass(frozen=True)
+class OperatorIntent:
+    """Presentation-neutral operator intent.
+
+    The contract deliberately contains no shell command and no execution
+    authority. Voice, TUI, Web and EUD surfaces may differ in presentation,
+    but equivalent actions must converge on this representation.
+    """
+
+    intent_id: str
+    source_modality: SourceModality
+    parameters: Mapping[str, Any] = field(default_factory=dict)
+    version: str = "1.0"
+    target_ref: Optional[str] = None
+    context_ref: Optional[str] = None
+    confidence: Optional[float] = None
+    clarification_state: ClarificationState = ClarificationState.NONE
+    confirmation_id: Optional[str] = None
+    correlation_id: str = field(default_factory=lambda: str(uuid4()))
+    audit_id: str = field(default_factory=lambda: str(uuid4()))
+
+    def semantic_payload(self) -> dict[str, Any]:
+        """Return modality-independent semantics for equivalence checks."""
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "intent_id": self.intent_id,
+            "version": self.version,
+            "target_ref": self.target_ref,
+            "context_ref": self.context_ref,
+            "parameters": dict(self.parameters),
+            "clarification_state": self.clarification_state.value,
+            "confirmation_id": self.confirmation_id,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = self.semantic_payload()
+        payload.update(
+            {
+                "source_modality": self.source_modality.value,
+                "confidence": self.confidence,
+                "correlation_id": self.correlation_id,
+                "audit_id": self.audit_id,
+            }
+        )
+        return payload
+
+    def with_modality(self, modality: SourceModality) -> "OperatorIntent":
+        return replace(self, source_modality=modality)
+
+
+@dataclass(frozen=True)
+class OperatorResult:
+    intent_id: str
+    status: str
+    correlation_id: str
+    audit_id: str
+    payload: Mapping[str, Any] = field(default_factory=dict)
+    confirmation_id: Optional[str] = None
+    message_code: Optional[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "intent_id": self.intent_id,
+            "status": self.status,
+            "correlation_id": self.correlation_id,
+            "audit_id": self.audit_id,
+            "confirmation_id": self.confirmation_id,
+            "message_code": self.message_code,
+            "payload": dict(self.payload),
+        }
+
+
+@dataclass
+class OperatorContext:
+    current_target: Optional[str] = None
+    current_context: Optional[str] = None
+    pending_confirmation_id: Optional[str] = None
+    pending_intent: Optional[OperatorIntent] = None
+    last_correlation_id: Optional[str] = None
+
+    def bind(self, intent: OperatorIntent) -> OperatorIntent:
+        """Carry task context across modality changes without inventing it."""
+        target = intent.target_ref or self.current_target
+        context = intent.context_ref or self.current_context
+        bound = replace(intent, target_ref=target, context_ref=context)
+        if target:
+            self.current_target = target
+        if context:
+            self.current_context = context
+        self.last_correlation_id = intent.correlation_id
+        return bound
+
+    def set_pending(self, intent: OperatorIntent, confirmation_id: Optional[str] = None) -> OperatorIntent:
+        identifier = confirmation_id or intent.confirmation_id or str(uuid4())
+        pending = replace(
+            intent,
+            clarification_state=ClarificationState.REQUIRED,
+            confirmation_id=identifier,
+        )
+        self.pending_confirmation_id = identifier
+        self.pending_intent = pending
+        return pending
+
+    def resolve_pending(self, approved: bool, modality: SourceModality) -> Optional[OperatorIntent]:
+        pending = self.pending_intent
+        if pending is None:
+            return None
+        state = ClarificationState.CONFIRMED if approved else ClarificationState.DENIED
+        resolved = replace(pending, source_modality=modality, clarification_state=state)
+        self.pending_confirmation_id = None
+        self.pending_intent = None
+        self.last_correlation_id = resolved.correlation_id
+        return resolved

--- a/babbly/core/operator_runtime.py
+++ b/babbly/core/operator_runtime.py
@@ -15,9 +15,10 @@ from babbly.core.operator_intent import (
 class OperatorIntentRuntime:
     """Shared core path for Voice/TUI/Web/EUD operator intents.
 
-    This initial runtime intentionally owns only read-only intents and DRY_RUN
-    representation of registered operations. Write-capable execution remains
-    outside this contract until the controlled request/approval work in #18.
+    This runtime owns read-only intents and the presentation-neutral request
+    state for registered local operations. It does not accept arbitrary shell
+    strings and it does not replace the registered command/SOP executor.
+    External-system write requests remain out of scope until #18.
     """
 
     READ_ONLY_INTENTS = {"situation.report", "recommendation.explain"}
@@ -119,20 +120,11 @@ class OperatorIntentRuntime:
                 message_code="operation.confirmation_required",
             )
 
-        if not self.dry_run:
-            return OperatorResult(
-                intent_id=intent.intent_id,
-                status="external_authority_required",
-                correlation_id=intent.correlation_id,
-                audit_id=intent.audit_id,
-                confirmation_id=intent.confirmation_id,
-                payload={"operation": operation, "target_ref": intent.target_ref},
-                message_code="operation.write_contract_not_enabled",
-            )
-
+        status = "dry_run" if self.dry_run else "ready_for_registered_executor"
+        code = "operation.dry_run" if self.dry_run else "operation.ready"
         return OperatorResult(
             intent_id=intent.intent_id,
-            status="dry_run",
+            status=status,
             correlation_id=intent.correlation_id,
             audit_id=intent.audit_id,
             confirmation_id=intent.confirmation_id,
@@ -141,7 +133,7 @@ class OperatorIntentRuntime:
                 "target_ref": intent.target_ref,
                 "context_ref": intent.context_ref,
             },
-            message_code="operation.dry_run",
+            message_code=code,
         )
 
     def resolve_pending(self, approved: bool, modality: SourceModality) -> OperatorResult:

--- a/babbly/core/operator_runtime.py
+++ b/babbly/core/operator_runtime.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from babbly.core.engine import SituationEngine
+from babbly.core.operator_intent import (
+    ClarificationState,
+    OperatorContext,
+    OperatorIntent,
+    OperatorResult,
+    SourceModality,
+)
+
+
+class OperatorIntentRuntime:
+    """Shared core path for Voice/TUI/Web/EUD operator intents.
+
+    This initial runtime intentionally owns only read-only intents and DRY_RUN
+    representation of registered operations. Write-capable execution remains
+    outside this contract until the controlled request/approval work in #18.
+    """
+
+    READ_ONLY_INTENTS = {"situation.report", "recommendation.explain"}
+
+    def __init__(
+        self,
+        situation_engine: Optional[SituationEngine] = None,
+        *,
+        dry_run: bool = False,
+        context: Optional[OperatorContext] = None,
+    ) -> None:
+        self.situation_engine = situation_engine or SituationEngine()
+        self.dry_run = bool(dry_run)
+        self.context = context or OperatorContext()
+
+    def submit(self, intent: OperatorIntent) -> OperatorResult:
+        bound = self.context.bind(intent)
+
+        if bound.intent_id == "situation.report":
+            snapshot = self.situation_engine.collect()
+            return OperatorResult(
+                intent_id=bound.intent_id,
+                status="ok",
+                correlation_id=bound.correlation_id,
+                audit_id=bound.audit_id,
+                payload={"snapshot": snapshot.to_dict()},
+                message_code="situation.snapshot",
+            )
+
+        if bound.intent_id == "recommendation.explain":
+            snapshot = self.situation_engine.collect()
+            top = snapshot.recommendations[0] if snapshot.recommendations else None
+            payload = {
+                "snapshot": snapshot.to_dict(),
+                "recommendation": (
+                    {
+                        "source": top.source,
+                        "action": top.action,
+                        "reason": top.reason,
+                        "priority": top.priority,
+                        "confidence": top.confidence,
+                        "advisory_only": top.advisory_only,
+                    }
+                    if top is not None
+                    else None
+                ),
+            }
+            return OperatorResult(
+                intent_id=bound.intent_id,
+                status="ok",
+                correlation_id=bound.correlation_id,
+                audit_id=bound.audit_id,
+                payload=payload,
+                message_code="recommendation.snapshot",
+            )
+
+        if bound.intent_id == "operation.run":
+            return self._submit_operation(bound)
+
+        return OperatorResult(
+            intent_id=bound.intent_id,
+            status="unsupported",
+            correlation_id=bound.correlation_id,
+            audit_id=bound.audit_id,
+            message_code="intent.unsupported",
+        )
+
+    def _submit_operation(self, intent: OperatorIntent) -> OperatorResult:
+        operation = str(intent.parameters.get("operation") or "").strip()
+        if not operation:
+            return OperatorResult(
+                intent_id=intent.intent_id,
+                status="invalid",
+                correlation_id=intent.correlation_id,
+                audit_id=intent.audit_id,
+                message_code="operation.missing_name",
+            )
+
+        if intent.clarification_state == ClarificationState.DENIED:
+            return OperatorResult(
+                intent_id=intent.intent_id,
+                status="denied",
+                correlation_id=intent.correlation_id,
+                audit_id=intent.audit_id,
+                confirmation_id=intent.confirmation_id,
+                payload={"operation": operation, "target_ref": intent.target_ref},
+                message_code="operation.denied",
+            )
+
+        if intent.clarification_state != ClarificationState.CONFIRMED:
+            pending = self.context.set_pending(intent)
+            return OperatorResult(
+                intent_id=pending.intent_id,
+                status="confirmation_required",
+                correlation_id=pending.correlation_id,
+                audit_id=pending.audit_id,
+                confirmation_id=pending.confirmation_id,
+                payload={"operation": operation, "target_ref": pending.target_ref},
+                message_code="operation.confirmation_required",
+            )
+
+        if not self.dry_run:
+            return OperatorResult(
+                intent_id=intent.intent_id,
+                status="external_authority_required",
+                correlation_id=intent.correlation_id,
+                audit_id=intent.audit_id,
+                confirmation_id=intent.confirmation_id,
+                payload={"operation": operation, "target_ref": intent.target_ref},
+                message_code="operation.write_contract_not_enabled",
+            )
+
+        return OperatorResult(
+            intent_id=intent.intent_id,
+            status="dry_run",
+            correlation_id=intent.correlation_id,
+            audit_id=intent.audit_id,
+            confirmation_id=intent.confirmation_id,
+            payload={
+                "operation": operation,
+                "target_ref": intent.target_ref,
+                "context_ref": intent.context_ref,
+            },
+            message_code="operation.dry_run",
+        )
+
+    def resolve_pending(self, approved: bool, modality: SourceModality) -> OperatorResult:
+        resolved = self.context.resolve_pending(approved, modality)
+        if resolved is None:
+            return OperatorResult(
+                intent_id="confirmation.resolve",
+                status="no_pending_confirmation",
+                correlation_id="",
+                audit_id="",
+                message_code="confirmation.none",
+            )
+        return self.submit(resolved)

--- a/babbly/core/situation.py
+++ b/babbly/core/situation.py
@@ -1,6 +1,6 @@
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Mapping, Optional
 
 
 @dataclass(frozen=True)
@@ -59,3 +59,45 @@ class SituationSnapshot:
             "observations": [asdict(item) for item in self.observations],
             "recommendations": [asdict(item) for item in self.recommendations],
         }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "SituationSnapshot":
+        snapshot = cls(status=str(payload.get("status") or "unknown"))
+        systems = payload.get("systems") or {}
+        if isinstance(systems, Mapping):
+            snapshot.systems = {str(key): str(value) for key, value in systems.items()}
+
+        observations = payload.get("observations") or []
+        if isinstance(observations, list):
+            for item in observations:
+                if not isinstance(item, Mapping):
+                    continue
+                snapshot.observations.append(
+                    Observation(
+                        source=str(item.get("source") or "unknown"),
+                        category=str(item.get("category") or "unknown"),
+                        summary=str(item.get("summary") or ""),
+                        severity=str(item.get("severity") or "info"),
+                        confidence=item.get("confidence"),
+                        data=dict(item.get("data") or {}),
+                        observed_at=str(item.get("observed_at") or datetime.now(timezone.utc).isoformat()),
+                    )
+                )
+
+        recommendations = payload.get("recommendations") or []
+        if isinstance(recommendations, list):
+            for item in recommendations:
+                if not isinstance(item, Mapping):
+                    continue
+                snapshot.recommendations.append(
+                    Recommendation(
+                        source=str(item.get("source") or "unknown"),
+                        action=str(item.get("action") or ""),
+                        reason=str(item.get("reason") or ""),
+                        priority=int(item.get("priority", 100)),
+                        confidence=item.get("confidence"),
+                        advisory_only=bool(item.get("advisory_only", True)),
+                    )
+                )
+        snapshot.recommendations.sort(key=lambda item: item.priority)
+        return snapshot

--- a/babbly/ja/main_program.py
+++ b/babbly/ja/main_program.py
@@ -8,7 +8,10 @@ import pyfiglet
 from babbly.adapters.factory import create_situation_engine
 from babbly.asr import create_asr
 from babbly.core.engine import SituationEngine
+from babbly.core.operator_intent import OperatorIntent, SourceModality
+from babbly.core.operator_runtime import OperatorIntentRuntime
 from babbly.core.render import render_recommendation_ja, render_situation_ja
+from babbly.core.situation import SituationSnapshot
 from babbly.ja.japanese_tts import Japanese_TTS
 from babbly.modules.commands_manager import CommandManager
 from babbly.modules.ipaddress_manager import IPAddressManager
@@ -25,13 +28,15 @@ from babbly.wake import create_wake_detector
 tts = Japanese_TTS()
 lang_ja = 1
 situation_engine = SituationEngine()
+operator_runtime = OperatorIntentRuntime(situation_engine)
 agent_profile = None
 
 
 def set_situation_engine(engine):
     """Inject read-only situation adapters without coupling the voice loop to Azazel."""
-    global situation_engine
+    global situation_engine, operator_runtime
     situation_engine = engine
+    operator_runtime.situation_engine = engine
 
 
 def set_agent_profile(profile):
@@ -42,13 +47,14 @@ def set_agent_profile(profile):
 
 def set_globals(config):
     global WAKEUP_PHRASE, EXIT_PHRASE, COMMANDS_PATH, TARGETS_PATH, SOP_PATH, DRY_RUN
-    global intent_resolver, intent_policy, domain_aliases
+    global intent_resolver, intent_policy, domain_aliases, operator_runtime
     WAKEUP_PHRASE = config.get("WAKEUP_PHRASE")
     EXIT_PHRASE = config.get("EXIT_PHRASE")
     COMMANDS_PATH = config.get("COMMANDS_PATH")
     TARGETS_PATH = config.get("TARGETS_PATH")
     SOP_PATH = config.get("SOP_PATH")
     DRY_RUN = bool(config.get("DRY_RUN", False))
+    operator_runtime.dry_run = DRY_RUN
 
     packs = config.get("DOMAIN_VOCABULARY", ["core", "kali"])
     domain_aliases = build_aliases(*packs)
@@ -64,6 +70,17 @@ def _persona_value(field, fallback):
         return fallback
     value = getattr(agent_profile.persona, field, None)
     return value or fallback
+
+
+def _voice_intent(intent_id, *, confidence=None, parameters=None, target_ref=None, context_ref=None):
+    return OperatorIntent(
+        intent_id=intent_id,
+        source_modality=SourceModality.VOICE,
+        confidence=confidence,
+        parameters=parameters or {},
+        target_ref=target_ref,
+        context_ref=context_ref,
+    )
 
 
 def introduce_agent():
@@ -106,15 +123,17 @@ def report_dry_run(action, detail=""):
     tts.say("ドライランのため、実際の処理は実行しません")
 
 
-def speak_situation_report():
-    snapshot = situation_engine.collect()
+def speak_situation_report(confidence=None):
+    result = operator_runtime.submit(_voice_intent("situation.report", confidence=confidence))
+    snapshot = SituationSnapshot.from_dict(result.payload.get("snapshot", {}))
     message = render_situation_ja(snapshot)
     print(message)
     tts.say(message)
 
 
-def speak_recommendation():
-    snapshot = situation_engine.collect()
+def speak_recommendation(confidence=None):
+    result = operator_runtime.submit(_voice_intent("recommendation.explain", confidence=confidence))
+    snapshot = SituationSnapshot.from_dict(result.payload.get("snapshot", {}))
     message = render_recommendation_ja(snapshot)
     print(message)
     tts.say(message)
@@ -195,11 +214,11 @@ def listen_for_command(asr):
                 break
 
             if intent.name == "situation.report":
-                speak_situation_report()
+                speak_situation_report(intent.confidence)
                 break
 
             if intent.name == "recommendation.explain":
-                speak_recommendation()
+                speak_recommendation(intent.confidence)
                 break
 
             if intent.name == "network.scan":
@@ -212,6 +231,7 @@ def listen_for_command(asr):
             if intent.name == "target.show":
                 target_name, target_ip = ip_mgr.find_target_ip(user_order)
                 if target_name:
+                    operator_runtime.context.current_target = target_ip
                     print(f"{target_name}: {target_ip}")
                     tts.say(f"{target_name}: {target_ip}")
                 else:
@@ -245,13 +265,33 @@ def listen_for_command(asr):
                     break
 
             if op_name:
-                if not ask_confirmation(asr, f"登録済みオペレーション {op_name} を実行します"):
+                canonical = _voice_intent(
+                    "operation.run",
+                    confidence=asr_result.confidence,
+                    parameters={"operation": op_name},
+                    target_ref=ipaddress,
+                    context_ref="registered-sop",
+                )
+                pending = operator_runtime.submit(canonical)
+                approved = ask_confirmation(asr, f"登録済みオペレーション {op_name} を実行します")
+                resolved = operator_runtime.resolve_pending(approved, SourceModality.VOICE)
+                logging.info(
+                    "canonical operation status=%s correlation=%s confirmation=%s",
+                    resolved.status,
+                    resolved.correlation_id,
+                    resolved.confirmation_id,
+                )
+                if not approved:
                     continue
                 if DRY_RUN:
                     report_dry_run("operation", op_name)
                     break
+                if resolved.status != "ready_for_registered_executor":
+                    tts.say("オペレーションを実行可能な状態にできませんでした")
+                    continue
                 if ipaddress is None:
                     ipaddress = select_target(ip_mgr, tts, asr, lang_ja)
+                    operator_runtime.context.current_target = ipaddress
                 op_mgr.run_operation(op_name, ipaddress)
                 break
 

--- a/docs/operator-intent-contract.md
+++ b/docs/operator-intent-contract.md
@@ -1,0 +1,91 @@
+# Canonical Operator Intent Contract
+
+Version: `babbly.operator-intent.v1`
+
+Babbly Core treats Voice, TUI, Web and wearable EUDs as presentation/input surfaces. They must not become separate command systems. Equivalent operator actions converge on one canonical operator-intent representation before they reach task logic, confirmation state, or registered executors.
+
+## Contract fields
+
+`OperatorIntent` carries:
+
+- `intent_id` and intent `version`
+- normalized `parameters`
+- `target_ref` and `context_ref`
+- `source_modality`: `voice`, `tui`, `web`, `eud`, or `test`
+- optional recognition `confidence`
+- clarification/confirmation state
+- `confirmation_id`
+- `correlation_id`
+- `audit_id`
+
+It intentionally does **not** carry arbitrary shell strings, adapter credentials, authority grants, profile-defined privileges, or threat/attention-derived privileges.
+
+## Agent profile relationship
+
+Agent identity is presentation configuration, not command authority.
+
+For example:
+
+- Generic Babbly may use the spoken name `バブリー`.
+- The Azazel-Edge profile uses `M.I.O` / `ミオ`.
+- Persona tone, verbosity, wake phrases and vocabulary may differ.
+
+Both resolve an equivalent operator action such as `situation.report` to the same canonical intent. Agent name/persona does not alter authorization, confirmation requirements, target binding, or external-system authority.
+
+This keeps the profile model compatible with `NORMAL / HEADS_UP / CRITICAL`: Agent Profile and OperatorAttentionState may both change presentation, but neither changes the canonical task truth or execution policy.
+
+## Context and modality switching
+
+`OperatorContext` retains:
+
+- current target
+- current task/context
+- pending confirmation identifier
+- pending canonical intent
+- last correlation identifier
+
+A request may therefore begin by voice and be confirmed or denied by Web/EUD without losing target, task, confirmation, correlation, or audit identity.
+
+Example:
+
+```text
+Voice: "recon-alpha を target A に実行"
+  -> operation.run
+  -> confirmation_required
+  -> confirmation_id = ...
+
+EUD: operator taps Approve
+  -> same pending intent
+  -> source_modality becomes eud
+  -> same correlation_id / audit_id / target / context
+```
+
+## Current runtime scope
+
+`OperatorIntentRuntime` currently provides the common path for:
+
+- `situation.report`
+- `recommendation.explain`
+- registered local `operation.run` confirmation state and DRY_RUN representation
+
+Registered operation execution remains owned by the existing registered SOP boundary. Arbitrary shell execution is not introduced by this contract.
+
+Write-capable requests to external systems are intentionally deferred to issue #18 and must remain separate from the read-only `SituationSnapshot` / Recommendation model.
+
+## Safety invariants
+
+- modality does not change execution policy;
+- Agent Profile does not grant authority;
+- OperatorAttentionState does not grant authority;
+- switching modality preserves task and confirmation context;
+- no arbitrary shell string is a canonical intent;
+- ASR/KWS/LLM components do not receive execution authority;
+- external systems retain their own decision authority.
+
+## Acceptance coverage
+
+Automated tests verify:
+
+- Voice and Web invoke `situation.report` through the same core runtime and receive equivalent snapshot data;
+- a registered operation has the same semantic representation from Voice and EUD under `DRY_RUN`;
+- a pending Voice confirmation can be resolved from Web while preserving target, context, confirmation, correlation and audit identifiers.

--- a/tests/test_operator_intent.py
+++ b/tests/test_operator_intent.py
@@ -1,0 +1,114 @@
+from babbly.core.operator_intent import OperatorIntent, SourceModality
+from babbly.core.operator_runtime import OperatorIntentRuntime
+from babbly.core.situation import Observation, Recommendation, SituationSnapshot
+
+
+class StaticSituationEngine:
+    def __init__(self):
+        self.snapshot = SituationSnapshot()
+        self.snapshot.set_system_state("azazel-edge", "online")
+        self.snapshot.add_observation(
+            Observation(
+                source="azazel-edge",
+                category="network",
+                summary="探索通信を検出",
+                severity="warning",
+                confidence=0.92,
+            )
+        )
+        self.snapshot.add_recommendation(
+            Recommendation(
+                source="azazel-edge",
+                action="Shield維持",
+                reason="探索通信を継続観測するため",
+                priority=1,
+                confidence=0.92,
+            )
+        )
+
+    def collect(self):
+        return self.snapshot
+
+
+def test_situation_report_uses_same_core_path_for_voice_and_web():
+    runtime = OperatorIntentRuntime(StaticSituationEngine(), dry_run=True)
+
+    voice = runtime.submit(OperatorIntent("situation.report", SourceModality.VOICE))
+    web = runtime.submit(OperatorIntent("situation.report", SourceModality.WEB))
+
+    assert voice.status == "ok"
+    assert web.status == "ok"
+    assert voice.payload == web.payload
+    assert voice.payload["snapshot"]["status"] == "warning"
+
+
+def test_registered_operation_has_same_semantics_from_voice_and_eud_under_dry_run():
+    voice_intent = OperatorIntent(
+        "operation.run",
+        SourceModality.VOICE,
+        parameters={"operation": "recon-alpha"},
+        target_ref="192.0.2.10",
+        context_ref="registered-sop",
+    )
+    eud_intent = OperatorIntent(
+        "operation.run",
+        SourceModality.EUD,
+        parameters={"operation": "recon-alpha"},
+        target_ref="192.0.2.10",
+        context_ref="registered-sop",
+    )
+
+    assert voice_intent.semantic_payload() == eud_intent.semantic_payload()
+
+    voice_runtime = OperatorIntentRuntime(dry_run=True)
+    eud_runtime = OperatorIntentRuntime(dry_run=True)
+    voice_runtime.submit(voice_intent)
+    eud_runtime.submit(eud_intent)
+
+    voice_result = voice_runtime.resolve_pending(True, SourceModality.VOICE)
+    eud_result = eud_runtime.resolve_pending(True, SourceModality.EUD)
+
+    assert voice_result.status == "dry_run"
+    assert eud_result.status == "dry_run"
+    assert voice_result.payload == eud_result.payload
+
+
+def test_modality_switch_preserves_pending_confirmation_and_context():
+    runtime = OperatorIntentRuntime(dry_run=True)
+    request = OperatorIntent(
+        "operation.run",
+        SourceModality.VOICE,
+        parameters={"operation": "recon-alpha"},
+        target_ref="192.0.2.50",
+        context_ref="task-17",
+    )
+
+    pending = runtime.submit(request)
+
+    assert pending.status == "confirmation_required"
+    assert runtime.context.pending_confirmation_id == pending.confirmation_id
+    assert runtime.context.current_target == "192.0.2.50"
+    assert runtime.context.current_context == "task-17"
+
+    result = runtime.resolve_pending(True, SourceModality.WEB)
+
+    assert result.status == "dry_run"
+    assert result.correlation_id == request.correlation_id
+    assert result.audit_id == request.audit_id
+    assert result.confirmation_id == pending.confirmation_id
+    assert result.payload["target_ref"] == "192.0.2.50"
+    assert result.payload["context_ref"] == "task-17"
+    assert runtime.context.pending_confirmation_id is None
+    assert runtime.context.pending_intent is None
+
+
+def test_profile_or_persona_is_not_part_of_authority_contract():
+    intent = OperatorIntent(
+        "situation.report",
+        SourceModality.VOICE,
+        parameters={"presentation_profile": "azazel-edge"},
+    )
+
+    assert "authority" not in intent.to_dict()
+    assert "shell" not in intent.to_dict()
+    assert intent.intent_id == "situation.report"


### PR DESCRIPTION
## Summary

Implements issue #15 and connects the existing profile-driven agent model to the attention-adaptive EUD architecture without making profile/persona part of execution authority.

## What changed

- added versioned `babbly.operator-intent.v1` contract
- added `SourceModality` for voice/tui/web/eud/test
- added normalized target/context/parameters, confidence, confirmation, correlation and audit metadata
- added `OperatorContext` to preserve target/task/pending-confirmation state across modality switches
- added `OperatorIntentRuntime` as the shared core path for `situation.report` and `recommendation.explain`
- added canonical representation and confirmation lifecycle for registered `operation.run`
- wired the Japanese voice surface through the canonical runtime for Situation/Recommendation and registered SOP confirmation
- kept Agent Profile (including M.I.O / ミオ) presentation-only: it does not grant authority or alter confirmations
- added `SituationSnapshot.from_dict()` for presentation surfaces consuming the canonical result payload
- documented the contract and its relationship to Agent Profiles and NORMAL/HEADS_UP/CRITICAL

## Acceptance criteria

- Voice and Web `situation.report` use the same runtime and return equivalent SituationSnapshot payloads
- Voice and EUD registered operations have identical semantic representation under DRY_RUN
- a Voice-origin pending confirmation can be resolved by Web while preserving target, context, confirmation, correlation and audit identity
- no arbitrary shell string or profile-defined authority is added

## Validation

macOS and Ubuntu CI compile/tests pass on the branch.

Closes #15