### PR TITLE
docs: sync status with implemented canonical operator-intent contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__/
 speech.txt
 speech.wav
+.venv/
+results/

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -14,6 +14,12 @@ Implemented on this branch:
 - short TTL cache to avoid duplicate reads during one collection
 - environment/token-file secret loading; no committed token
 - native Edge compatibility fallback when `status_view` is absent
+- Agent/environment profiles (`generic`, `kali`, `azazel-edge`) that project
+  identity/wake/persona/vocabulary/read-only source but never execution authority
+- canonical operator-intent contract `babbly.operator-intent.v1`
+  (`OperatorIntent`, `OperatorContext`, `OperatorIntentRuntime`) shared by
+  Voice/TUI/Web/EUD for `situation.report`, `recommendation.explain`, and
+  registered `operation.run` confirmation/DRY_RUN state
 - full tests and GitHub Actions coverage
 
 Not implemented yet:

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -1,12 +1,31 @@
 # Immediate next targets
 
-The Situation Model and first read-only situation intents are already implemented. The next work should move Babbly toward the attention-adaptive operator interaction defined in [`OPERATOR_INTERACTION_CONCEPT.md`](OPERATOR_INTERACTION_CONCEPT.md).
+The Situation Model, the first read-only situation intents, and the canonical
+operator-intent contract (`babbly.operator-intent.v1`, issue #15 / PR #22) are
+already implemented. The next work should move Babbly toward the
+attention-adaptive operator interaction defined in
+[`OPERATOR_INTERACTION_CONCEPT.md`](OPERATOR_INTERACTION_CONCEPT.md).
 
-1. Implement and benchmark a low-cost wake-word / KWS path so full ASR does not need to run continuously while idle.
-2. Record Raspberry Pi 5 live ASR/KWS measurements and keep the existing false-execution and intent-accuracy gates.
-3. Define a canonical operator-intent contract that can be invoked identically from voice and future visual surfaces while preserving target, task, confirmation, and audit context.
-4. Implement compact TUI/Web Situation rendering from the existing SituationSnapshot model; make the web surface responsive enough to serve as the first smartphone/EUD prototype.
-5. Add an operator-controlled `OperatorAttentionState` with NORMAL / HEADS_UP / CRITICAL presentation policy. Mode changes must alter information density and interaction style, never execution authority.
-6. Design the controlled request/approval path for write-capable integrations separately from the read-only Situation Model.
-7. Define the EUD-to-Core state/intent/session contract only after the canonical intent and controlled-request boundaries are stable.
-8. Add human-factors benchmark scenarios that measure eyes-on-device time, hands-on-device time, mode-switch continuity, workload, and task correctness in addition to ASR metrics.
+Tracking epic: #13. Canonical intent (#15) is complete and unblocks #16 and #17.
+
+1. (#16) Add an operator-controlled `OperatorAttentionState` with
+   NORMAL / HEADS_UP / CRITICAL presentation policy. Mode changes must alter
+   information density and interaction style, never execution authority.
+2. (#17) Implement compact TUI/Web Situation rendering from the existing
+   `SituationSnapshot` model; make the web surface responsive enough to serve as
+   the first smartphone/EUD prototype. Visual actions must invoke the canonical
+   operator intent, not a second command implementation.
+3. (#14) Implement and benchmark a low-cost wake-word / KWS path so full ASR does
+   not need to run continuously while idle. Complete the software layer on the
+   Mac; keep the Raspberry Pi 5 live ASR/KWS measurement as a separate hardware
+   gate. Preserve the existing false-execution and intent-accuracy gates.
+4. (#18) Design the controlled request/approval path for write-capable
+   integrations separately from the read-only Situation Model.
+5. (#19) Define the EUD-to-Core state/intent/session/reconnection contract only
+   after the canonical intent and controlled-request boundaries are stable.
+6. (#20) Build and field-test the responsive Web EUD on a forearm smartphone. A
+   native Android client is deferred until measurement proves the Web surface is
+   insufficient.
+7. (#21) Add human-factors benchmark scenarios that measure eyes-on-device time,
+   hands-on-device time, mode-switch continuity, workload, and task correctness
+   in addition to ASR metrics.


### PR DESCRIPTION
## Summary
Sync the status/roadmap docs with what actually landed on `main`, and fix a Mac-first setup hygiene gap found while validating the current tree.

- `docs/NEXT.md` still listed the canonical operator-intent contract as a *future* target, but #15 / #22 already delivered `babbly.operator-intent.v1`. Renumber the remaining targets against their tracking issues (#16, #17, #14, #18–#21) and note that #15 unblocks #16/#17.
- `docs/IMPLEMENTATION_STATUS.md`: record the agent/environment profile system and the operator-intent runtime as implemented.
- `.gitignore`: ignore `.venv/` and `results/` created by the documented Mac-first workflow.

## Validation
- `python -m pytest -q tests` → 58 passed (unchanged; docs/chore only).
- `python -m compileall -q babbly tools tests` → OK.

Docs/chore only; no code behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)