### PR TITLE
feat(core): OperatorAttentionState NORMAL/HEADS_UP/CRITICAL presentation policy (#16)

### DIFF
--- a/babbly/core/attention.py
+++ b/babbly/core/attention.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from enum import Enum
+from typing import List, Optional, Tuple
+
+
+class OperatorAttentionState(str, Enum):
+    """Operator-controlled attention budget.
+
+    This is deliberately separate from threat/system severity. It expresses how
+    much visual/manual attention the operator can currently spend on the device,
+    not how dangerous the situation is. It changes presentation only; it never
+    changes execution authority, confirmation policy, or the SituationSnapshot.
+    """
+
+    NORMAL = "normal"
+    HEADS_UP = "heads_up"
+    CRITICAL = "critical"
+
+
+@dataclass(frozen=True)
+class AttentionPresentationPolicy:
+    """Presentation density for one attention state.
+
+    Every field influences how the same SituationSnapshot/Recommendation is
+    rendered or which control affordances a surface should expose. None of these
+    fields grants execution capability: the runtime enforces authority and
+    confirmation identically regardless of attention state.
+    """
+
+    state: OperatorAttentionState
+    max_observations: int
+    include_adapter_health: bool
+    include_recommendation_reason: bool
+    include_action_affordances: bool
+    speech_verbosity: str  # "full" | "compact" | "minimal"
+    control_affordances: Tuple[str, ...]
+
+
+# Control affordances are presentation hints only. The executable intent set and
+# its confirmation rules are owned by OperatorIntentRuntime and do not change
+# with attention state. CRITICAL narrows the *visible* surface, not authority.
+_FULL_CONTROLS: Tuple[str, ...] = (
+    "situation.report",
+    "recommendation.explain",
+    "operation.run",
+    "confirm",
+    "deny",
+    "stop",
+    "repeat",
+)
+_ESSENTIAL_CONTROLS: Tuple[str, ...] = (
+    "situation.report",
+    "confirm",
+    "deny",
+    "stop",
+    "repeat",
+)
+
+
+_POLICIES = {
+    OperatorAttentionState.NORMAL: AttentionPresentationPolicy(
+        state=OperatorAttentionState.NORMAL,
+        max_observations=3,
+        include_adapter_health=True,
+        include_recommendation_reason=True,
+        include_action_affordances=True,
+        speech_verbosity="full",
+        control_affordances=_FULL_CONTROLS,
+    ),
+    OperatorAttentionState.HEADS_UP: AttentionPresentationPolicy(
+        state=OperatorAttentionState.HEADS_UP,
+        max_observations=2,
+        include_adapter_health=False,
+        include_recommendation_reason=False,
+        include_action_affordances=False,
+        speech_verbosity="compact",
+        control_affordances=_ESSENTIAL_CONTROLS,
+    ),
+    OperatorAttentionState.CRITICAL: AttentionPresentationPolicy(
+        state=OperatorAttentionState.CRITICAL,
+        max_observations=1,
+        include_adapter_health=False,
+        include_recommendation_reason=False,
+        include_action_affordances=False,
+        speech_verbosity="minimal",
+        control_affordances=_ESSENTIAL_CONTROLS,
+    ),
+}
+
+
+def policy_for(state: OperatorAttentionState) -> AttentionPresentationPolicy:
+    """Return the presentation policy for an attention state."""
+    return _POLICIES[OperatorAttentionState(state)]
+
+
+def coerce_state(value: object) -> OperatorAttentionState:
+    """Parse an operator-supplied attention state.
+
+    Accepts the enum, its value ("normal"/"heads_up"/"critical"), or common
+    spellings ("headsup", "heads-up"). Raises ValueError on anything else so an
+    unknown state fails closed instead of silently defaulting.
+    """
+    if isinstance(value, OperatorAttentionState):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower().replace("-", "_").replace(" ", "_")
+        if normalized == "headsup":
+            normalized = "heads_up"
+        for state in OperatorAttentionState:
+            if state.value == normalized:
+                return state
+    raise ValueError(f"unknown operator attention state: {value!r}")
+
+
+@dataclass(frozen=True)
+class AttentionTransition:
+    """One recorded, operator-initiated attention-state change."""
+
+    sequence: int
+    from_state: OperatorAttentionState
+    to_state: OperatorAttentionState
+    source_modality: str
+    reason: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return {
+            "sequence": self.sequence,
+            "from_state": self.from_state.value,
+            "to_state": self.to_state.value,
+            "source_modality": self.source_modality,
+            "reason": self.reason,
+        }
+
+
+@dataclass
+class AttentionController:
+    """Operator-controlled attention state with an auditable transition log.
+
+    Transitions happen only through :meth:`request_state`, which is driven by an
+    explicit operator action from some surface. There is no autonomous or
+    inferred transition: Babbly does not switch modes from speculative tactical
+    or battlefield judgment. Every accepted change is appended to ``history``.
+    """
+
+    state: OperatorAttentionState = OperatorAttentionState.NORMAL
+    history: List[AttentionTransition] = field(default_factory=list)
+
+    def request_state(
+        self,
+        state: object,
+        source_modality: str,
+        reason: Optional[str] = None,
+    ) -> AttentionTransition:
+        """Apply an operator-requested attention state and record the transition.
+
+        Any of the three states is reachable from any other (the operator may
+        jump NORMAL -> CRITICAL directly). A request for the current state is a
+        valid no-op that is still recorded, so the audit trail reflects every
+        deliberate operator action. Raises ValueError for an unknown state.
+        """
+        target = coerce_state(state)
+        transition = AttentionTransition(
+            sequence=len(self.history) + 1,
+            from_state=self.state,
+            to_state=target,
+            source_modality=str(source_modality),
+            reason=reason,
+        )
+        self.state = target
+        self.history.append(transition)
+        return transition
+
+    @property
+    def policy(self) -> AttentionPresentationPolicy:
+        return policy_for(self.state)
+
+    def snapshot(self) -> dict:
+        return {
+            "state": self.state.value,
+            "sequence": len(self.history),
+            "policy": {
+                "max_observations": self.policy.max_observations,
+                "speech_verbosity": self.policy.speech_verbosity,
+                "control_affordances": list(self.policy.control_affordances),
+            },
+        }

--- a/babbly/core/operator_runtime.py
+++ b/babbly/core/operator_runtime.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Optional
 
+from babbly.core.attention import AttentionController, coerce_state
 from babbly.core.engine import SituationEngine
 from babbly.core.operator_intent import (
     ClarificationState,
@@ -21,7 +22,8 @@ class OperatorIntentRuntime:
     External-system write requests remain out of scope until #18.
     """
 
-    READ_ONLY_INTENTS = {"situation.report", "recommendation.explain"}
+    READ_ONLY_INTENTS = {"situation.report", "recommendation.explain", "attention.status"}
+    PRESENTATION_INTENTS = {"attention.set", "attention.status"}
 
     def __init__(
         self,
@@ -29,10 +31,12 @@ class OperatorIntentRuntime:
         *,
         dry_run: bool = False,
         context: Optional[OperatorContext] = None,
+        attention: Optional[AttentionController] = None,
     ) -> None:
         self.situation_engine = situation_engine or SituationEngine()
         self.dry_run = bool(dry_run)
         self.context = context or OperatorContext()
+        self.attention = attention or AttentionController()
 
     def submit(self, intent: OperatorIntent) -> OperatorResult:
         bound = self.context.bind(intent)
@@ -73,6 +77,19 @@ class OperatorIntentRuntime:
                 audit_id=bound.audit_id,
                 payload=payload,
                 message_code="recommendation.snapshot",
+            )
+
+        if bound.intent_id == "attention.set":
+            return self._set_attention(bound)
+
+        if bound.intent_id == "attention.status":
+            return OperatorResult(
+                intent_id=bound.intent_id,
+                status="ok",
+                correlation_id=bound.correlation_id,
+                audit_id=bound.audit_id,
+                payload={"attention": self.attention.snapshot()},
+                message_code="attention.status",
             )
 
         if bound.intent_id == "operation.run":
@@ -134,6 +151,45 @@ class OperatorIntentRuntime:
                 "context_ref": intent.context_ref,
             },
             message_code=code,
+        )
+
+    def _set_attention(self, intent: OperatorIntent) -> OperatorResult:
+        """Apply an operator attention-state change.
+
+        Attention state is a presentation control: it is applied without
+        confirmation and it never alters execution authority, confirmation
+        policy, the pending operation, or the SituationSnapshot. An unknown
+        state fails closed.
+        """
+        try:
+            target = coerce_state(intent.parameters.get("state"))
+        except ValueError:
+            return OperatorResult(
+                intent_id=intent.intent_id,
+                status="invalid",
+                correlation_id=intent.correlation_id,
+                audit_id=intent.audit_id,
+                payload={"requested": intent.parameters.get("state")},
+                message_code="attention.invalid_state",
+            )
+
+        previous = self.attention.state
+        transition = self.attention.request_state(
+            target,
+            intent.source_modality.value,
+            reason=intent.parameters.get("reason"),
+        )
+        return OperatorResult(
+            intent_id=intent.intent_id,
+            status="ok",
+            correlation_id=intent.correlation_id,
+            audit_id=intent.audit_id,
+            payload={
+                "attention_state": self.attention.state.value,
+                "previous_state": previous.value,
+                "transition": transition.to_dict(),
+            },
+            message_code="attention.state_changed",
         )
 
     def resolve_pending(self, approved: bool, modality: SourceModality) -> OperatorResult:

--- a/babbly/core/render.py
+++ b/babbly/core/render.py
@@ -1,3 +1,8 @@
+from babbly.core.attention import (
+    AttentionPresentationPolicy,
+    OperatorAttentionState,
+    policy_for,
+)
 from babbly.core.situation import Recommendation, SituationSnapshot
 
 
@@ -50,4 +55,72 @@ def render_recommendation_ja(snapshot: SituationSnapshot) -> str:
         message += f"信頼度は{item.confidence:.0%}です。"
     if advisory:
         message += advisory + "。"
+    return message
+
+
+def render_situation_for_attention(
+    snapshot: SituationSnapshot,
+    state: OperatorAttentionState,
+) -> str:
+    """Render the situation at the density allowed by the attention state.
+
+    This is progressive disclosure over the *same* SituationSnapshot: NORMAL
+    exposes adapter health, more observations, and the recommendation; CRITICAL
+    compresses to the essentials for eyes-free use. It never changes the
+    snapshot itself and never adds or removes any capability.
+    """
+    policy: AttentionPresentationPolicy = policy_for(state)
+    status = STATUS_JA.get(snapshot.status, snapshot.status)
+    parts = [f"現在の状態は{status}です"]
+
+    if policy.include_adapter_health and snapshot.systems:
+        online = sum(1 for value in snapshot.systems.values() if value == "online")
+        errors = sum(1 for value in snapshot.systems.values() if value == "error")
+        parts.append(f"接続系統は{online}件正常")
+        if errors:
+            parts.append(f"{errors}件で取得エラー")
+
+    important = sorted(
+        snapshot.observations,
+        key=lambda item: {"critical": 0, "warning": 1, "caution": 2, "info": 3}.get(item.severity, 4),
+    )[: policy.max_observations]
+    if important:
+        parts.append("主な観測は" + "。".join(item.summary for item in important))
+    elif policy.speech_verbosity != "minimal":
+        parts.append("報告可能な観測はありません")
+
+    if snapshot.recommendations:
+        top = snapshot.recommendations[0]
+        if policy.include_recommendation_reason:
+            parts.append(f"最優先の推奨は{top.action}です。理由は{top.reason}です")
+        else:
+            parts.append(f"推奨は{top.action}")
+
+    return "。".join(parts) + "。"
+
+
+def render_recommendation_for_attention(
+    snapshot: SituationSnapshot,
+    state: OperatorAttentionState,
+) -> str:
+    """Render the top recommendation at the density allowed by the attention state.
+
+    The recommendation stays advisory in every state; attention mode only
+    controls how much of the reasoning is spoken, never whether it executes.
+    """
+    policy = policy_for(state)
+    if not snapshot.recommendations:
+        return "推奨なし。" if policy.speech_verbosity == "minimal" else "現在、提示できる推奨はありません。"
+
+    item: Recommendation = snapshot.recommendations[0]
+    if policy.speech_verbosity == "minimal":
+        return f"推奨は{item.action}。"
+
+    message = f"最優先の推奨は{item.action}です。"
+    if policy.include_recommendation_reason:
+        message += f"理由は{item.reason}です。"
+        if item.confidence is not None:
+            message += f"信頼度は{item.confidence:.0%}です。"
+    if item.advisory_only:
+        message += "助言のみです。"
     return message

--- a/docs/attention-state.md
+++ b/docs/attention-state.md
@@ -1,0 +1,53 @@
+# Operator attention state
+
+`OperatorAttentionState` is an operator-controlled presentation budget. It is
+defined in [`OPERATOR_INTERACTION_CONCEPT.md`](OPERATOR_INTERACTION_CONCEPT.md)
+and implemented in `babbly/core/attention.py`.
+
+It is deliberately **separate from threat/system severity**. It expresses how
+much visual and manual attention the operator can currently spend on the device,
+not how dangerous the situation is.
+
+## States
+
+| State       | Assumed operator attention        | Presentation                                             |
+| ----------- | --------------------------------- | -------------------------------------------------------- |
+| `NORMAL`    | visual-first, attention available | adapter health, up to 3 observations, recommendation reason, action affordances |
+| `HEADS_UP`  | reduced visual, voice preferred   | current target/findings, up to 2 observations, no health/reason |
+| `CRITICAL`  | eyes-free / hands-free            | concise spoken state, top observation only, essential controls |
+
+The same `SituationSnapshot` is rendered at different densities by
+`render_situation_for_attention()` and `render_recommendation_for_attention()`.
+This is progressive disclosure: the snapshot itself never changes.
+
+## Operator control only
+
+Transitions happen only through `AttentionController.request_state()`, driven by
+an explicit operator action from a surface. There is **no autonomous or inferred
+transition** — Babbly does not switch modes from speculative tactical or
+battlefield judgment. Every accepted change is appended to an auditable history
+(`sequence`, `from_state`, `to_state`, `source_modality`, `reason`).
+
+## Canonical intent path
+
+Attention changes travel through the same canonical operator-intent runtime as
+every other surface action, so Voice, TUI, Web and EUD request them identically:
+
+- `attention.set` — parameters `{"state": "normal" | "heads_up" | "critical"}`;
+  applied without confirmation; unknown state fails closed
+  (`attention.invalid_state`).
+- `attention.status` — read-only report of the current state and policy.
+
+## Authority invariants
+
+Attention state changes presentation only. It must never:
+
+- change execution authority or which operations are permitted;
+- weaken or add confirmation requirements;
+- alter a pending confirmation, target, context, correlation, or audit identity;
+- modify the underlying `SituationSnapshot`.
+
+`OperatorIntentRuntime` enforces operation confirmation and DRY_RUN behaviour
+identically in every attention mode; `tests/test_operator_attention.py` asserts
+this invariance across all three states, alongside coverage of every state
+transition and the density differences between renderings.

--- a/tests/test_operator_attention.py
+++ b/tests/test_operator_attention.py
@@ -1,0 +1,230 @@
+import pytest
+
+from babbly.core.attention import (
+    AttentionController,
+    OperatorAttentionState,
+    coerce_state,
+    policy_for,
+)
+from babbly.core.operator_intent import OperatorIntent, SourceModality
+from babbly.core.operator_runtime import OperatorIntentRuntime
+from babbly.core.render import (
+    render_recommendation_for_attention,
+    render_situation_for_attention,
+)
+from babbly.core.situation import Observation, Recommendation, SituationSnapshot
+
+
+ALL_STATES = list(OperatorAttentionState)
+
+
+def _rich_snapshot() -> SituationSnapshot:
+    snapshot = SituationSnapshot()
+    snapshot.set_system_state("azazel", "online")
+    snapshot.set_system_state("kali", "error")
+    snapshot.add_observation(Observation(source="azazel", category="state", summary="Edge稼働中", severity="info"))
+    snapshot.add_observation(Observation(source="azazel", category="alert", summary="探索通信を検出", severity="warning"))
+    snapshot.add_observation(Observation(source="azazel", category="alert", summary="再送を検出", severity="caution"))
+    snapshot.add_recommendation(
+        Recommendation(source="azazel", action="Shield維持", reason="探索通信を継続観測するため", priority=1, confidence=0.92)
+    )
+    return snapshot
+
+
+def _operation_intent(modality=SourceModality.VOICE) -> OperatorIntent:
+    return OperatorIntent(
+        intent_id="operation.run",
+        source_modality=modality,
+        parameters={"operation": "recon-alpha"},
+        target_ref="target-A",
+        context_ref="ctx-1",
+    )
+
+
+# --- state machine -----------------------------------------------------------
+
+def test_three_states_exist_and_are_distinct():
+    assert {s.value for s in OperatorAttentionState} == {"normal", "heads_up", "critical"}
+
+
+def test_controller_defaults_to_normal_with_empty_history():
+    controller = AttentionController()
+    assert controller.state is OperatorAttentionState.NORMAL
+    assert controller.history == []
+
+
+def test_every_transition_is_applied_and_recorded():
+    # Covers all 9 (from, to) ordered pairs, including no-op self-transitions.
+    for from_state in ALL_STATES:
+        for to_state in ALL_STATES:
+            controller = AttentionController(state=from_state)
+            transition = controller.request_state(to_state, "test")
+            assert controller.state is to_state
+            assert transition.from_state is from_state
+            assert transition.to_state is to_state
+            assert transition.sequence == 1
+            assert controller.history == [transition]
+
+
+def test_history_sequence_increments_and_preserves_order():
+    controller = AttentionController()
+    controller.request_state("heads_up", "voice")
+    controller.request_state("critical", "web", reason="hands busy")
+    controller.request_state("normal", "eud")
+    assert [t.sequence for t in controller.history] == [1, 2, 3]
+    assert [t.to_state.value for t in controller.history] == ["heads_up", "critical", "normal"]
+    assert controller.history[1].source_modality == "web"
+    assert controller.history[1].reason == "hands busy"
+
+
+def test_coerce_state_accepts_variants_and_rejects_unknown():
+    assert coerce_state("heads_up") is OperatorAttentionState.HEADS_UP
+    assert coerce_state("HEADS-UP") is OperatorAttentionState.HEADS_UP
+    assert coerce_state("headsup") is OperatorAttentionState.HEADS_UP
+    assert coerce_state(OperatorAttentionState.CRITICAL) is OperatorAttentionState.CRITICAL
+    with pytest.raises(ValueError):
+        coerce_state("panic")
+
+
+def test_request_state_fails_closed_on_unknown_state():
+    controller = AttentionController()
+    with pytest.raises(ValueError):
+        controller.request_state("panic", "voice")
+    assert controller.state is OperatorAttentionState.NORMAL
+    assert controller.history == []
+
+
+# --- presentation policy / rendering ----------------------------------------
+
+def test_same_snapshot_renders_with_decreasing_density():
+    snapshot = _rich_snapshot()
+    normal = render_situation_for_attention(snapshot, OperatorAttentionState.NORMAL)
+    heads_up = render_situation_for_attention(snapshot, OperatorAttentionState.HEADS_UP)
+    critical = render_situation_for_attention(snapshot, OperatorAttentionState.CRITICAL)
+
+    assert normal != heads_up != critical
+    assert len(normal) > len(heads_up) > len(critical)
+
+    # NORMAL exposes adapter health and the recommendation reason.
+    assert "接続系統" in normal
+    assert "理由は" in normal
+    # HEADS_UP / CRITICAL drop health and reasoning but keep the action.
+    assert "接続系統" not in heads_up and "接続系統" not in critical
+    assert "理由は" not in heads_up and "理由は" not in critical
+    assert "Shield維持" in normal and "Shield維持" in heads_up and "Shield維持" in critical
+
+
+def test_observation_count_matches_policy():
+    snapshot = _rich_snapshot()
+    for state in ALL_STATES:
+        text = render_situation_for_attention(snapshot, state)
+        policy = policy_for(state)
+        # The most severe observation (warning) always survives truncation.
+        assert "探索通信を検出" in text
+        if policy.max_observations < 3:
+            # the info-severity, lowest-priority observation is dropped
+            assert "Edge稼働中" not in text
+
+
+def test_recommendation_rendering_shrinks_with_attention():
+    snapshot = _rich_snapshot()
+    normal = render_recommendation_for_attention(snapshot, OperatorAttentionState.NORMAL)
+    critical = render_recommendation_for_attention(snapshot, OperatorAttentionState.CRITICAL)
+    assert "理由は" in normal and "92%" in normal
+    assert "理由は" not in critical
+    assert "Shield維持" in critical
+    assert len(normal) > len(critical)
+
+
+# --- canonical runtime integration ------------------------------------------
+
+def test_attention_set_from_voice_and_web_reach_same_state():
+    results = {}
+    for modality in (SourceModality.VOICE, SourceModality.WEB):
+        runtime = OperatorIntentRuntime()
+        result = runtime.submit(
+            OperatorIntent(intent_id="attention.set", source_modality=modality, parameters={"state": "critical"})
+        )
+        assert result.status == "ok"
+        assert result.message_code == "attention.state_changed"
+        assert result.payload["attention_state"] == "critical"
+        assert result.payload["previous_state"] == "normal"
+        results[modality] = runtime.attention.state
+    assert results[SourceModality.VOICE] == results[SourceModality.WEB] == OperatorAttentionState.CRITICAL
+
+
+def test_attention_set_invalid_state_fails_closed():
+    runtime = OperatorIntentRuntime()
+    result = runtime.submit(
+        OperatorIntent(intent_id="attention.set", source_modality=SourceModality.WEB, parameters={"state": "panic"})
+    )
+    assert result.status == "invalid"
+    assert result.message_code == "attention.invalid_state"
+    # unchanged
+    assert runtime.attention.state is OperatorAttentionState.NORMAL
+    assert runtime.attention.history == []
+
+
+def test_attention_status_is_read_only_reportable():
+    runtime = OperatorIntentRuntime()
+    runtime.attention.request_state("heads_up", "voice")
+    result = runtime.submit(
+        OperatorIntent(intent_id="attention.status", source_modality=SourceModality.TUI)
+    )
+    assert result.status == "ok"
+    assert result.payload["attention"]["state"] == "heads_up"
+
+
+# --- authority invariance across attention modes ----------------------------
+
+def test_operation_authority_is_identical_in_every_attention_mode():
+    """Attention mode changes presentation only, never execution/confirmation."""
+    pending_signatures = set()
+    confirmed_signatures = set()
+    for state in ALL_STATES:
+        runtime = OperatorIntentRuntime(dry_run=False)
+        runtime.attention.request_state(state, "test")
+
+        pending = runtime.submit(_operation_intent())
+        pending_signatures.add((pending.status, pending.message_code))
+
+        confirmed = runtime.resolve_pending(True, SourceModality.WEB)
+        confirmed_signatures.add((confirmed.status, confirmed.message_code))
+
+    assert pending_signatures == {("confirmation_required", "operation.confirmation_required")}
+    assert confirmed_signatures == {("ready_for_registered_executor", "operation.ready")}
+
+
+def test_dry_run_representation_is_identical_in_every_attention_mode():
+    confirmed_signatures = set()
+    for state in ALL_STATES:
+        runtime = OperatorIntentRuntime(dry_run=True)
+        runtime.attention.request_state(state, "test")
+        runtime.submit(_operation_intent())
+        confirmed = runtime.resolve_pending(True, SourceModality.WEB)
+        confirmed_signatures.add((confirmed.status, confirmed.message_code))
+    assert confirmed_signatures == {("dry_run", "operation.dry_run")}
+
+
+def test_mode_change_preserves_pending_confirmation_and_context():
+    runtime = OperatorIntentRuntime(dry_run=True)
+    pending = runtime.submit(_operation_intent(SourceModality.VOICE))
+    assert pending.status == "confirmation_required"
+    confirmation_id = pending.confirmation_id
+    correlation_id = pending.correlation_id
+
+    # Operator drops to CRITICAL mid-request; this must not clear the pending op.
+    switched = runtime.submit(
+        OperatorIntent(intent_id="attention.set", source_modality=SourceModality.EUD, parameters={"state": "critical"})
+    )
+    assert switched.status == "ok"
+    assert runtime.attention.state is OperatorAttentionState.CRITICAL
+    assert runtime.context.pending_confirmation_id == confirmation_id
+    assert runtime.context.pending_intent is not None
+
+    # The confirmation still resolves from a different modality, context intact.
+    confirmed = runtime.resolve_pending(True, SourceModality.WEB)
+    assert confirmed.status == "dry_run"
+    assert confirmed.correlation_id == correlation_id
+    assert confirmed.payload["target_ref"] == "target-A"
+    assert confirmed.payload["context_ref"] == "ctx-1"


### PR DESCRIPTION
## Summary
Implements #16. Adds an operator-controlled attention state that changes **presentation density only** — never system truth or execution authority.

- `OperatorAttentionState` (NORMAL / HEADS_UP / CRITICAL), deliberately separate from threat/system severity, with an auditable `AttentionController` transition log. Transitions are **operator-initiated only**, never autonomously inferred.
- `AttentionPresentationPolicy` + `render_situation_for_attention` / `render_recommendation_for_attention` render the same `SituationSnapshot` at decreasing density (progressive disclosure).
- Canonical `attention.set` / `attention.status` intents on `OperatorIntentRuntime`, so Voice/TUI/Web/EUD request mode changes identically. Unknown state fails closed; mode changes require no confirmation and touch no execution path.
- Docs: `docs/attention-state.md`.

## Acceptance criteria (issue #16)
- [x] deterministic tests cover every state transition (all 9 ordered pairs)
- [x] the same snapshot produces appropriately different NORMAL/HEADS_UP/CRITICAL renderings
- [x] execution-policy tests prove identical authorization/confirmation behaviour in all attention modes
- [x] mode change can occur without losing current task or pending confirmation context
- [x] no autonomous mode switch; underlying SituationSnapshot unchanged

## Validation
- `python -m pytest -q tests` → 73 passed (was 58; +15).
- `python -m compileall -q babbly tools tests` → OK (py3.10 and py3.11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)