### PR TITLE
build: make Apple Silicon Mac setup installable (vosk pin + cmake docs)

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-vosk = "*"
+vosk = "<0.3.45"
 faster-whisper = "*"
 numpy = "*"
 soundcard = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a3775541c206bfb10a06f61bae65498c2341cecd9580ca0e795fa495f187fd92"
+            "sha256": "99defc3d8236be2451659ee909da26b4adc99bcee7f790b6ebbca965507efb0f"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -676,14 +676,16 @@
         },
         "vosk": {
             "hashes": [
-                "sha256:25e025093c4399d7278f543568ed8cc5460ac3a4bf48c23673ace1e25d26619f",
-                "sha256:4221f83287eefe5abbe54fc6f1da5774e9e3ffcbbdca1705a466b341093b072e",
-                "sha256:54efb47dd890e544e9e20f0316413acec7f8680d04ec095c6140ab4e70262704",
-                "sha256:6994ddc68556c7e5730c3b6f6bad13320e3519b13ce3ed2aa25a86724e7c10ac"
+                "sha256:029d0b3d6a5cff874c575b8a5814a4cccfb37608cff52e846c02a8c67a882801",
+                "sha256:2652ef213c4c7807dc40af1e7aa578dcccfc4dc4192822a26bc45a9591bcbf76",
+                "sha256:45b1b1136a5cba6066c51da9f852dca7a855744db4ab72b23750c681d36f3202",
+                "sha256:93895a51b8bd7b4c780eef05a3d99bf2af03f02fe5f4e4bba3da17bd0fd69138",
+                "sha256:9995b7fa5434b134b4bd09897e2490dbc56115c2ad2943c030621e10c7037b34",
+                "sha256:a0d4a2c384692d721d4cda58aa79aac22edb0c445759e9ca2df61f44a5d2fdda"
             ],
             "index": "pypi",
             "markers": "python_version >= '3'",
-            "version": "==0.3.45"
+            "version": "==0.3.44"
         },
         "websockets": {
             "hashes": [

--- a/docs/development-macos.md
+++ b/docs/development-macos.md
@@ -23,17 +23,34 @@ The development workflow should remain compatible with Apple Silicon Macs genera
 
 The Mac and Pi audio devices are different. A successful Mac test is not evidence that microphone selection, gain, speaker output, or real-time audio timing is correct on the Pi.
 
+## Prerequisites
+
+- **Python 3.11** on the reference host. CI runs 3.11, and some pinned wheels
+  (e.g. `vosk`) do not publish an Apple Silicon build for 3.10. Use a 3.11
+  interpreter to create the virtual environment.
+- **CMake** is required to build the offline TTS dependency `pyopenjtalk` from
+  source: `brew install cmake`. With CMake 4.x, export
+  `CMAKE_POLICY_VERSION_MINIMUM=3.5` before installing so the vendored
+  `open_jtalk`/`hts_engine` sources still configure.
+
 ## Initial setup
 
 ```bash
-python3 -m venv .venv
+# Use a Python 3.11 interpreter for the virtual environment.
+python3.11 -m venv .venv
 source .venv/bin/activate
 python -m pip install --upgrade pip
 python -m pip install pipenv
 pipenv requirements > /tmp/babbly-requirements.txt
-python -m pip install -r /tmp/babbly-requirements.txt
+# CMAKE_POLICY_VERSION_MINIMUM is only needed with CMake >= 4.
+CMAKE_POLICY_VERSION_MINIMUM=3.5 python -m pip install -r /tmp/babbly-requirements.txt
 python -m pip install "pytest>=8,<10"
 ```
+
+The offline ASR model is a separate, uncommitted asset. `vosk` expects a model
+directory at `MODEL_PATH` (default `babbly/ja/model`); provision it before
+running the full voice loop. Tests, `--list-profiles`, and profile/DRY_RUN
+startup do not require the model.
 
 Run tests:
 


### PR DESCRIPTION
## Summary
The documented Mac-first setup does not install as-is on Apple Silicon. Two problems found while validating `main` on a MacBook Pro (M-series):

1. `Pipfile.lock` pinned `vosk==0.3.45`, which has **no macOS arm64 distribution** (PyPI tops out at 0.3.44). `pipenv requirements | pip install` therefore fails on Apple Silicon.
2. The offline TTS dep `pyopenjtalk` builds from source and needs CMake (+ `CMAKE_POLICY_VERSION_MINIMUM=3.5` on CMake 4.x); this wasn't documented.

## Changes
- `Pipfile`: `vosk = "<0.3.45"`.
- `Pipfile.lock`: re-point the `vosk` stanza to the installable 0.3.44 wheels and update the Pipfile hash so `pipenv requirements` stays in sync (targeted 14-line edit, no other pins touched).
- `docs/development-macos.md`: document Python 3.11, the CMake prerequisite, the CMake-4 policy env var, and the separate offline ASR model asset.

## Validation
- `python -m pipenv requirements` → emits `vosk==0.3.44`, no out-of-date warning.
- Full documented setup completes on Apple Silicon (venv py3.11): `pyopenjtalk` builds, `import babbly.ja.main_program` OK, `--list-profiles` and DRY_RUN startup work.
- `python -m pytest -q tests` → 73 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)