### PR TITLE
feat(surface): compact TUI + responsive Web Situation surface (#17)

### DIFF
--- a/babbly/core/surface.py
+++ b/babbly/core/surface.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from babbly.core.attention import OperatorAttentionState, policy_for
+from babbly.core.render import STATUS_JA
+from babbly.core.situation import SituationSnapshot
+
+
+_SEVERITY_ORDER = {"critical": 0, "warning": 1, "caution": 2, "info": 3}
+
+
+def build_situation_view(
+    snapshot: SituationSnapshot,
+    attention_state: OperatorAttentionState,
+    *,
+    pending_confirmation: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Build the shared presentation view-model for TUI and Web surfaces.
+
+    TUI and Web render from this single model so the two surfaces cannot drift
+    into separate presentations of the same SituationSnapshot. The model is
+    presentation-neutral data only: it carries no execution capability and never
+    mutates the snapshot. Density follows the attention presentation policy.
+    """
+    state = OperatorAttentionState(attention_state)
+    policy = policy_for(state)
+
+    online = sum(1 for value in snapshot.systems.values() if value == "online")
+    errors = sum(1 for value in snapshot.systems.values() if value == "error")
+    systems_summary = {"online": online, "error": errors, "total": len(snapshot.systems)}
+
+    observations = [
+        {"summary": item.summary, "severity": item.severity, "source": item.source}
+        for item in sorted(
+            snapshot.observations,
+            key=lambda item: _SEVERITY_ORDER.get(item.severity, 4),
+        )[: policy.max_observations]
+    ]
+
+    recommendation: Optional[Dict[str, Any]] = None
+    if snapshot.recommendations:
+        top = snapshot.recommendations[0]
+        recommendation = {
+            "action": top.action,
+            "advisory_only": top.advisory_only,
+            "confidence": top.confidence if policy.include_recommendation_reason else None,
+            "reason": top.reason if policy.include_recommendation_reason else None,
+        }
+
+    view: Dict[str, Any] = {
+        "schema": "babbly.situation-view.v1",
+        "attention_state": state.value,
+        "speech_verbosity": policy.speech_verbosity,
+        "status": snapshot.status,
+        "status_label": STATUS_JA.get(snapshot.status, snapshot.status),
+        "systems_summary": systems_summary,
+        "systems": (
+            [{"name": name, "state": value} for name, value in sorted(snapshot.systems.items())]
+            if policy.include_adapter_health
+            else []
+        ),
+        "observations": observations,
+        "recommendation": recommendation,
+        "controls": list(policy.control_affordances),
+        "pending_confirmation": pending_confirmation,
+        "degraded": errors > 0,
+    }
+    return view
+
+
+def render_tui(view: Dict[str, Any]) -> str:
+    """Render the shared view-model as a compact terminal panel.
+
+    Progressive disclosure: NORMAL shows adapter health and the recommendation
+    reason; HEADS_UP/CRITICAL compress to the current status, top findings, and
+    the recommended action.
+    """
+    lines: List[str] = []
+    lines.append(f"[{view['attention_state'].upper()}] 状態: {view['status_label']}")
+
+    summary = view["systems_summary"]
+    if view["systems"]:
+        detail = "  ".join(f"{s['name']}={s['state']}" for s in view["systems"])
+        lines.append(f"系統: 正常{summary['online']}/{summary['total']}  {detail}")
+    elif summary["total"]:
+        suffix = f" (エラー{summary['error']})" if summary["error"] else ""
+        lines.append(f"系統: 正常{summary['online']}/{summary['total']}{suffix}")
+
+    if view["degraded"]:
+        lines.append("⚠ 一部アダプタが取得エラー")
+
+    if view["observations"]:
+        lines.append("観測:")
+        for obs in view["observations"]:
+            lines.append(f"  - [{obs['severity']}] {obs['summary']}")
+    else:
+        lines.append("観測: なし")
+
+    rec = view["recommendation"]
+    if rec:
+        line = f"推奨: {rec['action']}"
+        if rec.get("reason"):
+            line += f" — {rec['reason']}"
+        if rec.get("advisory_only"):
+            line += "（助言）"
+        lines.append(line)
+
+    pending = view["pending_confirmation"]
+    if pending:
+        lines.append(f"確認待ち: {pending.get('operation', '?')} → 承認/却下")
+
+    return "\n".join(lines)

--- a/babbly/web/__init__.py
+++ b/babbly/web/__init__.py
@@ -1,0 +1,3 @@
+from babbly.web.server import SituationWebApp, make_server, serve
+
+__all__ = ["SituationWebApp", "make_server", "serve"]

--- a/babbly/web/__main__.py
+++ b/babbly/web/__main__.py
@@ -1,0 +1,15 @@
+import argparse
+
+from babbly.web.server import serve
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Babbly compact Situation surface (Web/EUD prototype)")
+    parser.add_argument("--host", default="127.0.0.1", help="bind address (default: loopback)")
+    parser.add_argument("--port", type=int, default=8787, help="port (default: 8787)")
+    args = parser.parse_args()
+    serve(host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/babbly/web/server.py
+++ b/babbly/web/server.py
@@ -1,0 +1,270 @@
+"""Compact responsive Web/TUI Situation surface (issue #17).
+
+This is the first Babbly EUD prototype: a smartphone-friendly web view over the
+existing `SituationSnapshot`, driven entirely through the canonical operator
+intent runtime. It is a presentation/input surface, not a second command
+system:
+
+- reads go through the canonical `situation.report` intent;
+- the only write it accepts is a presentation change (`attention.set`) plus the
+  read intents, all on the same `OperatorIntentRuntime` used by voice;
+- it never executes registered operations or arbitrary shell strings. The
+  controlled write/approval path is deferred to #18.
+
+It depends only on `babbly.core` and the Python standard library, so it runs
+without the offline voice/ASR stack.
+"""
+
+from __future__ import annotations
+
+import json
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Dict, Optional, Tuple
+
+from babbly.core.operator_intent import OperatorIntent, SourceModality
+from babbly.core.operator_runtime import OperatorIntentRuntime
+from babbly.core.situation import SituationSnapshot
+from babbly.core.surface import build_situation_view
+
+
+# Surfaces may request reads and presentation changes only. Operation execution
+# and any external write remain outside this prototype (see #18).
+ALLOWED_WEB_INTENTS = {
+    "situation.report",
+    "recommendation.explain",
+    "attention.status",
+    "attention.set",
+}
+
+
+class SituationWebApp:
+    """Framework-neutral request handling for the Situation surface.
+
+    The dispatch logic is a pure function of (method, path, body) so it can be
+    tested without opening a socket. ``make_server`` wires it to the standard
+    library HTTP server.
+    """
+
+    def __init__(self, runtime: Optional[OperatorIntentRuntime] = None) -> None:
+        self.runtime = runtime or OperatorIntentRuntime()
+
+    # -- view model -----------------------------------------------------------
+
+    def current_view(self) -> Dict[str, Any]:
+        """Collect the situation through the canonical read intent and render it."""
+        result = self.runtime.submit(
+            OperatorIntent(intent_id="situation.report", source_modality=SourceModality.WEB)
+        )
+        snapshot = SituationSnapshot.from_dict(result.payload.get("snapshot", {}))
+        return build_situation_view(
+            snapshot,
+            self.runtime.attention.state,
+            pending_confirmation=self._pending_confirmation(),
+        )
+
+    def _pending_confirmation(self) -> Optional[Dict[str, Any]]:
+        pending = self.runtime.context.pending_intent
+        if pending is None:
+            return None
+        return {
+            "operation": pending.parameters.get("operation"),
+            "confirmation_id": self.runtime.context.pending_confirmation_id,
+            "target_ref": pending.target_ref,
+        }
+
+    # -- dispatch -------------------------------------------------------------
+
+    def handle(self, method: str, path: str, body: bytes = b"") -> Tuple[int, str, bytes]:
+        route = path.split("?", 1)[0].rstrip("/") or "/"
+
+        if method == "GET" and route == "/":
+            return 200, "text/html; charset=utf-8", INDEX_HTML.encode("utf-8")
+
+        if method == "GET" and route == "/api/situation":
+            return self._json(200, self.current_view())
+
+        if method == "POST" and route == "/api/intent":
+            return self._handle_intent(body)
+
+        return self._json(404, {"error": "not_found", "path": route})
+
+    def _handle_intent(self, body: bytes) -> Tuple[int, str, bytes]:
+        try:
+            payload = json.loads(body.decode("utf-8") or "{}")
+            if not isinstance(payload, dict):
+                raise ValueError("intent body must be an object")
+        except (ValueError, UnicodeDecodeError) as exc:
+            return self._json(400, {"error": "invalid_json", "detail": str(exc)})
+
+        intent_id = payload.get("intent_id")
+        if intent_id not in ALLOWED_WEB_INTENTS:
+            # Fail closed: the web surface cannot invoke anything outside the
+            # read/presentation allowlist.
+            return self._json(
+                400,
+                {"error": "intent_not_allowed", "intent_id": intent_id, "allowed": sorted(ALLOWED_WEB_INTENTS)},
+            )
+
+        parameters = payload.get("parameters")
+        intent = OperatorIntent(
+            intent_id=intent_id,
+            source_modality=SourceModality.WEB,
+            parameters=parameters if isinstance(parameters, dict) else {},
+            target_ref=payload.get("target_ref"),
+            context_ref=payload.get("context_ref"),
+        )
+        result = self.runtime.submit(intent)
+        status = 200 if result.status in {"ok", "confirmation_required"} else 400
+        return self._json(status, {"result": result.to_dict(), "view": self.current_view()})
+
+    @staticmethod
+    def _json(status: int, data: Dict[str, Any]) -> Tuple[int, str, bytes]:
+        return status, "application/json; charset=utf-8", json.dumps(data, ensure_ascii=False).encode("utf-8")
+
+
+def make_server(app: SituationWebApp, host: str = "127.0.0.1", port: int = 8787) -> ThreadingHTTPServer:
+    """Bind a threading HTTP server that delegates to ``app.handle``."""
+
+    class _Handler(BaseHTTPRequestHandler):
+        def _dispatch(self, method: str) -> None:
+            length = int(self.headers.get("Content-Length") or 0)
+            body = self.rfile.read(length) if length else b""
+            status, content_type, payload = app.handle(method, self.path, body)
+            self.send_response(status)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def do_GET(self) -> None:  # noqa: N802 - stdlib naming
+            self._dispatch("GET")
+
+        def do_POST(self) -> None:  # noqa: N802 - stdlib naming
+            self._dispatch("POST")
+
+        def log_message(self, *_args) -> None:  # silence default stderr logging
+            return
+
+    return ThreadingHTTPServer((host, port), _Handler)
+
+
+def serve(host: str = "127.0.0.1", port: int = 8787, runtime: Optional[OperatorIntentRuntime] = None) -> None:
+    """Run the Situation surface until interrupted (local prototype; binds loopback)."""
+    app = SituationWebApp(runtime)
+    server = make_server(app, host, port)
+    print(f"Babbly Situation surface on http://{host}:{port}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+INDEX_HTML = """<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>Babbly Situation</title>
+<style>
+  :root { color-scheme: light dark; --gap: 12px; }
+  * { box-sizing: border-box; }
+  body { margin: 0; font-family: system-ui, sans-serif; line-height: 1.5;
+         padding: env(safe-area-inset-top) 14px calc(env(safe-area-inset-bottom) + 14px); }
+  h1 { font-size: 1.05rem; margin: 14px 0 8px; }
+  .status { font-size: 1.6rem; font-weight: 700; margin: 4px 0 2px; overflow-wrap: anywhere; }
+  .muted { opacity: .7; font-size: .85rem; }
+  .card { border: 1px solid rgba(128,128,128,.35); border-radius: 12px;
+          padding: 12px; margin: var(--gap) 0; }
+  .obs { display: flex; gap: 8px; padding: 6px 0; border-top: 1px solid rgba(128,128,128,.2); overflow-wrap: anywhere; }
+  .obs:first-child { border-top: 0; }
+  .sev { font-size: .7rem; padding: 2px 8px; border-radius: 999px; align-self: center;
+         white-space: nowrap; background: rgba(128,128,128,.25); }
+  .sev.warning, .sev.critical { background: #c0392b; color: #fff; }
+  .sev.caution { background: #e67e22; color: #fff; }
+  .modes { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 8px; }
+  button { font: inherit; padding: 14px 8px; border-radius: 12px; border: 1px solid rgba(128,128,128,.4);
+           background: rgba(128,128,128,.12); min-height: 52px; cursor: pointer; }
+  button.active { background: #2d6cdf; color: #fff; border-color: #2d6cdf; }
+  .degraded { color: #c0392b; font-weight: 600; }
+  .err { color: #c0392b; }
+</style>
+</head>
+<body>
+  <h1>Babbly Situation <span id="conn" class="muted"></span></h1>
+  <div class="card">
+    <div class="muted" id="mode">—</div>
+    <div class="status" id="status">…</div>
+    <div class="muted" id="systems"></div>
+    <div class="degraded" id="degraded" hidden>⚠ 一部アダプタが取得エラー</div>
+  </div>
+  <div class="card">
+    <div class="muted">観測</div>
+    <div id="observations"></div>
+  </div>
+  <div class="card" id="recCard" hidden>
+    <div class="muted">推奨</div>
+    <div id="recommendation"></div>
+  </div>
+  <div class="card" id="pendingCard" hidden>
+    <div class="muted">確認待ち</div>
+    <div id="pending"></div>
+  </div>
+  <div class="modes">
+    <button data-mode="normal">NORMAL</button>
+    <button data-mode="heads_up">HEADS-UP</button>
+    <button data-mode="critical">CRITICAL</button>
+  </div>
+<script>
+const $ = (id) => document.getElementById(id);
+function render(v) {
+  $("conn").textContent = "";
+  $("mode").textContent = "モード: " + v.attention_state.toUpperCase();
+  $("status").textContent = v.status_label;
+  const s = v.systems_summary;
+  $("systems").textContent = s.total ? ("系統 正常 " + s.online + "/" + s.total) : "";
+  $("degraded").hidden = !v.degraded;
+  const obs = $("observations"); obs.innerHTML = "";
+  if (!v.observations.length) { obs.innerHTML = '<div class="muted">なし</div>'; }
+  for (const o of v.observations) {
+    const row = document.createElement("div"); row.className = "obs";
+    const sev = document.createElement("span"); sev.className = "sev " + o.severity; sev.textContent = o.severity;
+    const txt = document.createElement("span"); txt.textContent = o.summary;
+    row.append(sev, txt); obs.append(row);
+  }
+  const rc = $("recCard");
+  if (v.recommendation) {
+    rc.hidden = false;
+    let t = v.recommendation.action;
+    if (v.recommendation.reason) t += " — " + v.recommendation.reason;
+    if (v.recommendation.advisory_only) t += "（助言）";
+    $("recommendation").textContent = t;
+  } else { rc.hidden = true; }
+  const pc = $("pendingCard");
+  if (v.pending_confirmation) {
+    pc.hidden = false;
+    $("pending").textContent = (v.pending_confirmation.operation || "?") + " → 承認/却下";
+  } else { pc.hidden = true; }
+  for (const b of document.querySelectorAll("button[data-mode]"))
+    b.classList.toggle("active", b.dataset.mode === v.attention_state);
+}
+async function refresh() {
+  try { const r = await fetch("/api/situation"); render(await r.json()); }
+  catch (e) { $("conn").innerHTML = '<span class="err">接続エラー</span>'; }
+}
+async function setMode(mode) {
+  try {
+    const r = await fetch("/api/intent", { method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ intent_id: "attention.set", parameters: { state: mode } }) });
+    const data = await r.json(); if (data.view) render(data.view);
+  } catch (e) { $("conn").innerHTML = '<span class="err">接続エラー</span>'; }
+}
+for (const b of document.querySelectorAll("button[data-mode]"))
+  b.addEventListener("click", () => setMode(b.dataset.mode));
+refresh(); setInterval(refresh, 3000);
+</script>
+</body>
+</html>
+"""

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -20,6 +20,12 @@ Implemented on this branch:
   (`OperatorIntent`, `OperatorContext`, `OperatorIntentRuntime`) shared by
   Voice/TUI/Web/EUD for `situation.report`, `recommendation.explain`, and
   registered `operation.run` confirmation/DRY_RUN state
+- `OperatorAttentionState` (NORMAL/HEADS_UP/CRITICAL) presentation policy with
+  operator-only, auditable transitions and `attention.set` / `attention.status`
+  intents; authority is identical in every mode
+- shared Situation view-model (`babbly.situation-view.v1`) with a compact TUI
+  renderer and a responsive Web surface (`python -m babbly.web`) as the first
+  EUD prototype; visual actions route through canonical intents only
 - full tests and GitHub Actions coverage
 
 Not implemented yet:
@@ -28,6 +34,6 @@ Not implemented yet:
 - autonomous actions from Situation Model
 - low-cost wake-word / keyword-spotting backend
 - Raspberry Pi 5 live ASR/KWS benchmark measurements
-- TUI/Web situation rendering
+- native Android EUD client
 
 The Azazel integration is intentionally read-only. Edge remains the authority for Azazel actions.

--- a/docs/situation-surface.md
+++ b/docs/situation-surface.md
@@ -1,0 +1,56 @@
+# Situation surface (TUI / Web EUD prototype)
+
+Issue #17. A compact visual surface over the existing `SituationSnapshot`,
+intended as the **first Babbly EUD prototype** — a smartphone-friendly view for
+brief-glance use on a forearm-mounted phone, before any native Android client is
+considered.
+
+## One presentation model, two surfaces
+
+`babbly/core/surface.py` builds a single presentation-neutral view-model
+(`babbly.situation-view.v1`) from a `SituationSnapshot`:
+
+- `build_situation_view(snapshot, attention_state)` — status, adapter health,
+  prioritized observations, top recommendation, pending confirmation, and a
+  `degraded` flag, all at the density allowed by the attention state.
+- `render_tui(view)` — a compact terminal panel from the same view-model.
+
+Both the TUI and the Web page render from this one model, so the surfaces cannot
+drift into separate presentations of the same situation. Density follows
+[`attention-state.md`](attention-state.md): NORMAL exposes adapter health and the
+recommendation reason; HEADS_UP/CRITICAL compress progressively.
+
+## Canonical intents only
+
+`babbly/web/server.py` (`SituationWebApp`) is a presentation/input surface, not a
+second command system. All actions go through the shared `OperatorIntentRuntime`:
+
+- `GET /api/situation` reads via the canonical `situation.report` intent.
+- `POST /api/intent` accepts only an allowlist of read/presentation intents
+  (`situation.report`, `recommendation.explain`, `attention.status`,
+  `attention.set`). Anything else — including `operation.run` — is rejected
+  (`intent_not_allowed`). The controlled write/approval path is deferred to #18.
+
+The web page's mode buttons submit `attention.set`, so a visual action reaches
+the same canonical intent path a voice command would, and the view immediately
+re-renders at the new density.
+
+## Running it
+
+```bash
+python -m babbly.web            # http://127.0.0.1:8787
+python -m babbly.web --port 9000
+```
+
+It binds loopback by default and depends only on `babbly.core` and the standard
+library, so it runs without the offline voice/ASR stack. A bare runtime with no
+situation adapters shows an empty ("状況不明") snapshot; wire a situation source
+(e.g. the read-only Azazel-Edge adapter) to populate it.
+
+## Safety
+
+- The surface never executes registered operations or shell strings.
+- Adapter/transport failure is represented (`degraded`, systems in `error`)
+  instead of crashing the surface.
+- Changing attention mode from the surface changes presentation only; execution
+  authority and confirmation policy are unchanged (see `attention-state.md`).

--- a/tests/test_situation_surface.py
+++ b/tests/test_situation_surface.py
@@ -1,0 +1,76 @@
+from babbly.core.attention import OperatorAttentionState
+from babbly.core.situation import Observation, Recommendation, SituationSnapshot
+from babbly.core.surface import build_situation_view, render_tui
+
+
+def _rich_snapshot() -> SituationSnapshot:
+    snapshot = SituationSnapshot()
+    snapshot.set_system_state("azazel", "online")
+    snapshot.set_system_state("kali", "error")
+    snapshot.add_observation(Observation(source="azazel", category="state", summary="Edge稼働中", severity="info"))
+    snapshot.add_observation(Observation(source="azazel", category="alert", summary="探索通信を検出", severity="warning"))
+    snapshot.add_observation(Observation(source="azazel", category="alert", summary="再送を検出", severity="caution"))
+    snapshot.add_recommendation(
+        Recommendation(source="azazel", action="Shield維持", reason="継続観測のため", priority=1, confidence=0.92)
+    )
+    return snapshot
+
+
+def test_view_normal_exposes_full_density():
+    view = build_situation_view(_rich_snapshot(), OperatorAttentionState.NORMAL)
+    assert view["attention_state"] == "normal"
+    assert view["status"] == "warning"
+    assert view["status_label"] == "警戒"
+    assert view["systems_summary"] == {"online": 1, "error": 1, "total": 2}
+    assert view["systems"]  # adapter health exposed in NORMAL
+    assert len(view["observations"]) == 3
+    assert view["recommendation"]["reason"] == "継続観測のため"
+    assert view["recommendation"]["confidence"] == 0.92
+    assert view["degraded"] is True
+
+
+def test_view_critical_is_compressed_but_same_snapshot():
+    snapshot = _rich_snapshot()
+    view = build_situation_view(snapshot, OperatorAttentionState.CRITICAL)
+    assert view["systems"] == []  # health suppressed
+    assert len(view["observations"]) == 1
+    assert view["observations"][0]["summary"] == "探索通信を検出"  # most severe survives
+    assert view["recommendation"]["action"] == "Shield維持"
+    assert view["recommendation"]["reason"] is None  # reasoning suppressed
+    # underlying snapshot is untouched
+    assert len(snapshot.observations) == 3
+
+
+def test_view_density_decreases_with_attention():
+    snapshot = _rich_snapshot()
+    counts = [
+        len(build_situation_view(snapshot, state)["observations"])
+        for state in (OperatorAttentionState.NORMAL, OperatorAttentionState.HEADS_UP, OperatorAttentionState.CRITICAL)
+    ]
+    assert counts == sorted(counts, reverse=True)
+    assert counts[0] > counts[-1]
+
+
+def test_view_pending_confirmation_is_passed_through():
+    pending = {"operation": "recon-alpha", "confirmation_id": "c1", "target_ref": "target-A"}
+    view = build_situation_view(_rich_snapshot(), OperatorAttentionState.NORMAL, pending_confirmation=pending)
+    assert view["pending_confirmation"] == pending
+
+
+def test_render_tui_normal_vs_critical():
+    snapshot = _rich_snapshot()
+    normal = render_tui(build_situation_view(snapshot, OperatorAttentionState.NORMAL))
+    critical = render_tui(build_situation_view(snapshot, OperatorAttentionState.CRITICAL))
+    assert "警戒" in normal and "警戒" in critical
+    assert "探索通信を検出" in normal and "探索通信を検出" in critical
+    assert "azazel=online" in normal  # adapter detail only in NORMAL
+    assert "azazel=online" not in critical
+    assert "継続観測のため" in normal and "継続観測のため" not in critical
+    assert len(normal) > len(critical)
+
+
+def test_render_tui_handles_empty_snapshot():
+    view = build_situation_view(SituationSnapshot(), OperatorAttentionState.NORMAL)
+    text = render_tui(view)
+    assert "観測: なし" in text
+    assert view["degraded"] is False

--- a/tests/test_web_surface.py
+++ b/tests/test_web_surface.py
@@ -1,0 +1,120 @@
+import json
+import threading
+import urllib.request
+
+from babbly.core.attention import OperatorAttentionState
+from babbly.core.operator_runtime import OperatorIntentRuntime
+from babbly.core.situation import Observation, Recommendation, SituationSnapshot
+from babbly.web.server import SituationWebApp, make_server
+
+
+class _FakeEngine:
+    """Return a fixed snapshot so surface tests are deterministic."""
+
+    def __init__(self, snapshot: SituationSnapshot) -> None:
+        self._snapshot = snapshot
+
+    def collect(self) -> SituationSnapshot:
+        return self._snapshot
+
+
+def _snapshot(*, degraded: bool = False) -> SituationSnapshot:
+    snapshot = SituationSnapshot()
+    snapshot.set_system_state("azazel", "online")
+    if degraded:
+        snapshot.set_system_state("kali", "error")
+    snapshot.add_observation(Observation(source="azazel", category="state", summary="Edge稼働中", severity="info"))
+    snapshot.add_observation(Observation(source="azazel", category="alert", summary="探索通信を検出", severity="warning"))
+    snapshot.add_observation(Observation(source="azazel", category="alert", summary="再送を検出", severity="caution"))
+    snapshot.add_recommendation(Recommendation(source="azazel", action="Shield維持", reason="継続観測", priority=1))
+    return snapshot
+
+
+def _app(snapshot=None) -> SituationWebApp:
+    runtime = OperatorIntentRuntime(situation_engine=_FakeEngine(snapshot or _snapshot()))
+    return SituationWebApp(runtime)
+
+
+def _json_body(body: bytes):
+    return json.loads(body.decode("utf-8"))
+
+
+def test_index_is_served_as_responsive_html():
+    status, content_type, body = _app().handle("GET", "/")
+    assert status == 200
+    assert "text/html" in content_type
+    text = body.decode("utf-8")
+    assert "<title>Babbly Situation" in text
+    assert "width=device-width" in text  # responsive viewport
+
+
+def test_api_situation_matches_snapshot_via_canonical_intent():
+    status, content_type, body = _app().handle("GET", "/api/situation")
+    assert status == 200
+    assert "application/json" in content_type
+    view = _json_body(body)
+    assert view["attention_state"] == "normal"
+    assert view["status"] == "warning"
+    assert [o["summary"] for o in view["observations"]] == ["探索通信を検出", "再送を検出", "Edge稼働中"]
+    assert view["recommendation"]["action"] == "Shield維持"
+
+
+def test_visual_action_reaches_canonical_intent_and_changes_density():
+    app = _app()
+    body = json.dumps({"intent_id": "attention.set", "parameters": {"state": "critical"}}).encode()
+    status, _ct, resp = app.handle("POST", "/api/intent", body)
+    assert status == 200
+    data = _json_body(resp)
+    assert data["result"]["status"] == "ok"
+    assert data["result"]["message_code"] == "attention.state_changed"
+    # the runtime's shared attention state changed...
+    assert app.runtime.attention.state is OperatorAttentionState.CRITICAL
+    # ...and the returned + subsequent view render at the new density.
+    assert data["view"]["attention_state"] == "critical"
+    assert len(data["view"]["observations"]) == 1
+    follow = _json_body(app.handle("GET", "/api/situation")[2])
+    assert follow["attention_state"] == "critical"
+
+
+def test_web_surface_rejects_non_allowlisted_intents():
+    app = _app()
+    body = json.dumps({"intent_id": "operation.run", "parameters": {"operation": "recon-alpha"}}).encode()
+    status, _ct, resp = app.handle("POST", "/api/intent", body)
+    assert status == 400
+    assert _json_body(resp)["error"] == "intent_not_allowed"
+    # the rejected write never created a pending confirmation
+    assert app.runtime.context.pending_intent is None
+
+
+def test_web_surface_rejects_malformed_json():
+    status, _ct, resp = _app().handle("POST", "/api/intent", b"{not json")
+    assert status == 400
+    assert _json_body(resp)["error"] == "invalid_json"
+
+
+def test_unknown_route_is_404_not_a_crash():
+    status, _ct, resp = _app().handle("GET", "/nope")
+    assert status == 404
+    assert _json_body(resp)["error"] == "not_found"
+
+
+def test_degraded_adapter_is_represented():
+    view = _json_body(_app(_snapshot(degraded=True)).handle("GET", "/api/situation")[2])
+    assert view["degraded"] is True
+    assert view["systems_summary"]["error"] == 1
+
+
+def test_end_to_end_over_a_real_socket():
+    server = make_server(_app(), host="127.0.0.1", port=0)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = server.server_address[0], server.server_address[1]
+        with urllib.request.urlopen(f"http://{host}:{port}/api/situation", timeout=5) as resp:
+            assert resp.status == 200
+            view = json.loads(resp.read().decode("utf-8"))
+            assert view["schema"] == "babbly.situation-view.v1"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)


### PR DESCRIPTION
## Summary
Implements #17. The first Babbly EUD prototype — a smartphone-friendly visual surface over the existing `SituationSnapshot`, driven **only through canonical operator intents**.

- `babbly/core/surface.py`: one presentation-neutral view-model (`babbly.situation-view.v1`) shared by the TUI and the Web page, plus `render_tui()`. Density follows the `OperatorAttentionState` policy (progressive disclosure) and never mutates the snapshot.
- `babbly/web/server.py`: stdlib-only `SituationWebApp`. `GET /api/situation` reads via the canonical `situation.report` intent; `POST /api/intent` accepts only a read/presentation allowlist and rejects everything else (incl. `operation.run`). The responsive page's NORMAL/HEADS-UP/CRITICAL buttons submit `attention.set`, so a visual action reaches the same canonical intent path as voice, and the view re-renders at the new density. Adapter failure is shown (`degraded`) without crashing.
- `python -m babbly.web` runs it (binds loopback, needs no voice/ASR stack).

Depends only on `babbly.core` + stdlib, so it runs in CI.

## Acceptance criteria (issue #17)
- [x] a smartphone browser can display a live SituationSnapshot without horizontal scrolling (responsive viewport, `overflow-wrap`, single-column cards)
- [x] `situation.report` info is consistent with the spoken rendering (same view-model / STATUS labels)
- [x] at least one visual action reaches the canonical intent path from #15 (mode buttons → `attention.set`)
- [x] adapter/transport failure is clearly represented without crashing (`degraded`, systems in `error`; unknown route → 404; malformed JSON → 400)
- [x] automated rendering/data-contract tests included (14 new tests, incl. a real-socket end-to-end check)

Integrates #16: the surface renders at the current `OperatorAttentionState` density.

## Validation
- `python -m pytest -q tests` → 87 passed (was 73; +14).
- `python -m compileall -q babbly tools tests` → OK.
- Live: `python -m babbly.web` serves `/`, `/api/situation`, and `attention.set` via POST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)