### PR TITLE
feat(wake): separable EnergyVad stage for the speech-entry pipeline (#14)

### DIFF
--- a/babbly/asr/faster_whisper_backend.py
+++ b/babbly/asr/faster_whisper_backend.py
@@ -6,6 +6,7 @@ import numpy as np
 import sounddevice as sd
 
 from babbly.asr.types import ASRResult
+from babbly.wake.vad import EnergyVad, VadEvent
 
 
 class FasterWhisperASR:
@@ -46,8 +47,14 @@ class FasterWhisperASR:
         silent_blocks_required = max(1, int(self.silence_seconds / block_seconds))
         max_blocks = max(1, int(self.max_seconds / block_seconds))
         chunks: List[np.ndarray] = []
-        speech_started = False
-        silent_blocks = 0
+
+        # Utterance boundaries come from the shared energy VAD stage so idle
+        # capture (no speech) never feeds the full ASR model.
+        vad = EnergyVad(
+            rms_threshold=self.rms_threshold,
+            start_frames=1,
+            hangover_frames=silent_blocks_required,
+        )
 
         with sd.InputStream(
             samplerate=self.sample_rate,
@@ -60,17 +67,14 @@ class FasterWhisperASR:
                 mono = np.asarray(data[:, 0], dtype=np.float32)
                 rms = float(np.sqrt(np.mean(np.square(mono)))) if mono.size else 0.0
 
-                if rms >= self.rms_threshold:
-                    speech_started = True
-                    silent_blocks = 0
-                    chunks.append(mono.copy())
-                elif speech_started:
-                    chunks.append(mono.copy())
-                    silent_blocks += 1
-                    if silent_blocks >= silent_blocks_required:
-                        break
-                else:
+                event = vad.observe_rms(rms)
+                if event is VadEvent.SILENCE:
                     time.sleep(0.01)
+                    continue
+
+                chunks.append(mono.copy())
+                if event is VadEvent.SPEECH_END:
+                    break
 
         if not chunks:
             return np.array([], dtype=np.float32)

--- a/babbly/wake/vad.py
+++ b/babbly/wake/vad.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import Enum
+from typing import Iterable, Sequence
+
+
+class VadEvent(str, Enum):
+    """Frame-level voice-activity classification with utterance boundaries."""
+
+    SILENCE = "silence"          # quiet, no active utterance
+    SPEECH_START = "speech_start"  # first frame of a new utterance
+    SPEECH = "speech"            # ongoing utterance (loud, or within hangover)
+    SPEECH_END = "speech_end"    # hangover elapsed; utterance closed on this frame
+
+
+@dataclass
+class EnergyVad:
+    """Low-cost energy voice-activity detector.
+
+    This is the separable VAD stage of the speech-entry pipeline
+    (VAD -> wake/KWS -> full ASR). It decides *whether there is speech*, never
+    *what was said*, so it can gate expensive full-ASR inference while idle
+    without any model asset. It has no action authority.
+
+    A short hysteresis avoids chattering: ``start_frames`` consecutive loud
+    frames open an utterance and ``hangover_frames`` consecutive quiet frames
+    close it, so brief dips inside speech do not end the utterance.
+    """
+
+    rms_threshold: float = 0.012
+    start_frames: int = 1
+    hangover_frames: int = 8
+
+    def __post_init__(self) -> None:
+        self.rms_threshold = max(0.0, float(self.rms_threshold))
+        self.start_frames = max(1, int(self.start_frames))
+        self.hangover_frames = max(1, int(self.hangover_frames))
+        self.reset()
+
+    def reset(self) -> None:
+        self._in_speech = False
+        self._loud_run = 0
+        self._quiet_run = 0
+
+    @property
+    def in_speech(self) -> bool:
+        return self._in_speech
+
+    @staticmethod
+    def rms(samples: Sequence[float]) -> float:
+        """Root-mean-square level of a frame; 0.0 for an empty frame."""
+        total = 0.0
+        count = 0
+        for value in samples:
+            total += float(value) * float(value)
+            count += 1
+        if count == 0:
+            return 0.0
+        return math.sqrt(total / count)
+
+    def observe_rms(self, rms: float) -> VadEvent:
+        """Advance the state machine by one frame given its RMS level."""
+        loud = float(rms) >= self.rms_threshold
+
+        if not self._in_speech:
+            if loud:
+                self._loud_run += 1
+                if self._loud_run >= self.start_frames:
+                    self._in_speech = True
+                    self._loud_run = 0
+                    self._quiet_run = 0
+                    return VadEvent.SPEECH_START
+            else:
+                self._loud_run = 0
+            return VadEvent.SILENCE
+
+        # in speech
+        if loud:
+            self._quiet_run = 0
+            return VadEvent.SPEECH
+        self._quiet_run += 1
+        if self._quiet_run >= self.hangover_frames:
+            self._in_speech = False
+            self._quiet_run = 0
+            self._loud_run = 0
+            return VadEvent.SPEECH_END
+        return VadEvent.SPEECH
+
+    def observe_frame(self, samples: Sequence[float]) -> VadEvent:
+        return self.observe_rms(self.rms(samples))
+
+    def speech_present(self, frames: Iterable[Sequence[float]]) -> bool:
+        """True if any utterance opens across a sequence of frames.
+
+        Convenience for an idle gate: if this returns False for a window of
+        captured frames, full ASR does not need to run.
+        """
+        for frame in frames:
+            event = self.observe_frame(frame)
+            if event in (VadEvent.SPEECH_START, VadEvent.SPEECH):
+                return True
+        return False

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -26,14 +26,19 @@ Implemented on this branch:
 - shared Situation view-model (`babbly.situation-view.v1`) with a compact TUI
   renderer and a responsive Web surface (`python -m babbly.web`) as the first
   EUD prototype; visual actions route through canonical intents only
+- separated speech-entry stages: `EnergyVad` (model-free energy VAD),
+  replaceable wake backends (ASR compatibility gate + optional sherpa-onnx KWS),
+  and full command ASR, so idle operation does not run full ASR continuously
+- offline wake benchmark corpus and FAR/FRR/latency evaluator
+  (`tools/evaluate_wake_results.py`)
 - full tests and GitHub Actions coverage
 
 Not implemented yet:
 
 - write/action request contract
 - autonomous actions from Situation Model
-- low-cost wake-word / keyword-spotting backend
-- Raspberry Pi 5 live ASR/KWS benchmark measurements
+- Raspberry Pi 5 live ASR/KWS field-benchmark measurements (hardware-gated;
+  Mac-side software layer is complete)
 - native Android EUD client
 
 The Azazel integration is intentionally read-only. Edge remains the authority for Azazel actions.

--- a/docs/wake-kws.md
+++ b/docs/wake-kws.md
@@ -6,6 +6,7 @@ Babbly separates wake detection from command speech recognition so the full ASR 
 
 ```text
 microphone
+  -> VAD (energy)                         # is there speech at all?
   -> WakeDetector
        -> ASR compatibility gate (default)
        -> sherpa-onnx KWS (optional)
@@ -15,7 +16,25 @@ microphone
   -> registered action or read-only query
 ```
 
-Wake detection has deliberately low authority. A trigger may only open the command-listening window. It cannot create an intent, select a target, or execute an action.
+VAD, wake/KWS, and full ASR are kept as separate responsibilities so idle
+operation does not require continuous full ASR inference. Wake detection has
+deliberately low authority. A trigger may only open the command-listening
+window. It cannot create an intent, select a target, or execute an action.
+
+## VAD stage
+
+`babbly/wake/vad.py` provides `EnergyVad`, a low-cost, model-free energy voice
+activity detector. It decides *whether there is speech*, never *what was said*,
+so it can gate expensive full-ASR inference while idle without any model asset,
+and it has no action authority.
+
+`EnergyVad` is a small hysteresis state machine over per-frame RMS:
+`start_frames` consecutive loud frames open an utterance and `hangover_frames`
+consecutive quiet frames close it (a brief dip inside speech does not end the
+utterance). It emits `SPEECH_START` / `SPEECH` / `SPEECH_END` / `SILENCE`
+events. The faster-whisper backend uses it to bound utterance capture, so a
+silent window is never transcribed. Its decision logic is covered by
+deterministic unit tests independent of any microphone or model.
 
 ## Backends
 

--- a/tests/test_wake_vad.py
+++ b/tests/test_wake_vad.py
@@ -1,0 +1,72 @@
+import math
+
+from babbly.wake.vad import EnergyVad, VadEvent
+
+
+def test_rms_of_constant_and_empty_frames():
+    assert EnergyVad.rms([]) == 0.0
+    assert EnergyVad.rms([0.0, 0.0, 0.0]) == 0.0
+    assert math.isclose(EnergyVad.rms([0.5, -0.5, 0.5, -0.5]), 0.5)
+
+
+def test_single_loud_frame_starts_speech():
+    vad = EnergyVad(rms_threshold=0.1, start_frames=1, hangover_frames=3)
+    assert vad.observe_rms(0.5) is VadEvent.SPEECH_START
+    assert vad.in_speech is True
+    assert vad.observe_rms(0.5) is VadEvent.SPEECH
+
+
+def test_start_requires_consecutive_loud_frames():
+    vad = EnergyVad(rms_threshold=0.1, start_frames=2, hangover_frames=3)
+    assert vad.observe_rms(0.5) is VadEvent.SILENCE   # 1 loud, not enough
+    assert vad.observe_rms(0.0) is VadEvent.SILENCE   # quiet resets the loud run
+    assert vad.observe_rms(0.5) is VadEvent.SILENCE   # 1 again
+    assert vad.observe_rms(0.5) is VadEvent.SPEECH_START  # 2 consecutive
+
+
+def test_hangover_closes_utterance_and_loud_resets_quiet_run():
+    vad = EnergyVad(rms_threshold=0.1, start_frames=1, hangover_frames=3)
+    assert vad.observe_rms(0.5) is VadEvent.SPEECH_START
+    assert vad.observe_rms(0.0) is VadEvent.SPEECH   # quiet 1
+    assert vad.observe_rms(0.0) is VadEvent.SPEECH   # quiet 2
+    assert vad.observe_rms(0.5) is VadEvent.SPEECH   # loud resets the quiet run
+    assert vad.observe_rms(0.0) is VadEvent.SPEECH   # quiet 1 again
+    assert vad.observe_rms(0.0) is VadEvent.SPEECH   # quiet 2
+    assert vad.observe_rms(0.0) is VadEvent.SPEECH_END  # quiet 3 -> hangover
+    assert vad.in_speech is False
+
+
+def test_reset_clears_state():
+    vad = EnergyVad(rms_threshold=0.1, start_frames=1, hangover_frames=2)
+    vad.observe_rms(0.5)
+    assert vad.in_speech is True
+    vad.reset()
+    assert vad.in_speech is False
+    assert vad.observe_rms(0.0) is VadEvent.SILENCE
+
+
+def test_speech_present_convenience():
+    quiet = [[0.0] * 4 for _ in range(5)]
+    loud = quiet[:2] + [[0.5, -0.5, 0.5, -0.5]] + quiet[:2]
+    assert EnergyVad(rms_threshold=0.1).speech_present(quiet) is False
+    assert EnergyVad(rms_threshold=0.1).speech_present(loud) is True
+
+
+def test_capture_parity_appends_until_hangover():
+    # Mirrors FasterWhisperASR._capture_utterance: append on any non-silence
+    # event, break on SPEECH_END, sleep/skip on SILENCE.
+    vad = EnergyVad(rms_threshold=0.1, start_frames=1, hangover_frames=2)
+    rms_sequence = [0.0, 0.0, 0.5, 0.5, 0.0, 0.0, 0.5]  # trailing loud never reached
+    appended = []
+    broke_at = None
+    for i, rms in enumerate(rms_sequence):
+        event = vad.observe_rms(rms)
+        if event is VadEvent.SILENCE:
+            continue
+        appended.append(i)
+        if event is VadEvent.SPEECH_END:
+            broke_at = i
+            break
+    # frames 0,1 are pre-speech silence (skipped); 2,3 speech; 4 quiet(1); 5 quiet(2)->end
+    assert appended == [2, 3, 4, 5]
+    assert broke_at == 5


### PR DESCRIPTION
## Summary
Advances #14 on the Mac-side software layer. Makes VAD an explicit, model-free, deterministically testable stage separate from wake/KWS and full ASR, so idle operation does not require continuous full ASR inference.

- `babbly/wake/vad.py`: `EnergyVad`, an RMS hysteresis state machine (`start_frames` to open, `hangover_frames` to close) emitting `SPEECH_START`/`SPEECH`/`SPEECH_END`/`SILENCE`. It decides *whether there is speech*, never *what was said*, and has no action authority.
- faster-whisper capture now bounds utterances through `EnergyVad` instead of ad-hoc RMS bookkeeping (behaviour preserved; the gating logic is now covered by deterministic tests, including a capture-parity test).
- docs: name the VAD stage in the pipeline (`wake-kws.md`); record in `IMPLEMENTATION_STATUS.md` that the wake/KWS software layer (VAD + replaceable ASR/sherpa-onnx backends + FAR/FRR/latency evaluator) is complete and only the **Raspberry Pi 5 field measurements remain (hardware-gated)**.

## #14 status
- [x] low-cost wake/KWS backend behind a replaceable interface (existing sherpa-onnx + ASR gate)
- [x] VAD, wake/KWS, and full ASR kept as separate responsibilities (this PR adds the discrete VAD stage)
- [x] deterministic NLU/policy boundary preserved (94 passed)
- [ ] repeatable Pi 5 field benchmarks — deferred to real hardware; tooling (corpus + evaluator) is ready

## Validation
- `python -m pytest -q tests` → 94 passed (was 87; +7).
- `python -m compileall -q babbly tools tests` → OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)