### PR TITLE
feat(core): controlled request/approval contract for write actions (#18)

### DIFF
--- a/babbly/core/request.py
+++ b/babbly/core/request.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable, Dict, List, Mapping, Optional, Protocol, runtime_checkable
+from uuid import uuid4
+
+
+SCHEMA_VERSION = "babbly.action-request.v1"
+
+
+class RiskClass(str, Enum):
+    """Advisory risk/confirmation class. It never removes the human approval
+    requirement; higher risk may only add friction in a surface, not authority."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+class RequestState(str, Enum):
+    PENDING_APPROVAL = "pending_approval"
+    APPROVED = "approved"
+    DENIED = "denied"
+    CANCELLED = "cancelled"
+    TIMED_OUT = "timed_out"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+# Terminal states cannot transition further.
+_TERMINAL = {
+    RequestState.DENIED,
+    RequestState.CANCELLED,
+    RequestState.TIMED_OUT,
+    RequestState.COMPLETED,
+    RequestState.FAILED,
+}
+
+
+class RequestError(Exception):
+    """Raised on an illegal controlled-request transition."""
+
+
+@dataclass(frozen=True)
+class ActionRequest:
+    """The only contract by which Babbly asks an external executor to change state.
+
+    It is deliberately distinct from the read-only SituationSnapshot/Recommendation
+    model and carries no shell string, credentials, or authority grant. The action
+    is an identifier; parameters are normalized values. Approval is always a
+    separate, explicit human step (see ControlledRequestManager).
+    """
+
+    action: str
+    parameters: Mapping[str, Any] = field(default_factory=dict)
+    target_ref: Optional[str] = None
+    context_ref: Optional[str] = None
+    risk_class: RiskClass = RiskClass.MEDIUM
+    requested_by_modality: str = "unknown"
+    request_id: str = field(default_factory=lambda: str(uuid4()))
+    correlation_id: str = field(default_factory=lambda: str(uuid4()))
+    audit_id: str = field(default_factory=lambda: str(uuid4()))
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "request_id": self.request_id,
+            "action": self.action,
+            "parameters": dict(self.parameters),
+            "target_ref": self.target_ref,
+            "context_ref": self.context_ref,
+            "risk_class": self.risk_class.value,
+            "requested_by_modality": self.requested_by_modality,
+            "correlation_id": self.correlation_id,
+            "audit_id": self.audit_id,
+        }
+
+
+@dataclass(frozen=True)
+class ExecutionResult:
+    """Outcome returned by an external executor after an approved dispatch."""
+
+    ok: bool
+    detail: str = ""
+    external_ref: Optional[str] = None
+    rejected_by_executor: bool = False
+
+
+@runtime_checkable
+class ActionExecutor(Protocol):
+    """Write-capable external authority.
+
+    A distinct method name (``execute_action``) keeps read-only situation
+    adapters from accidentally satisfying the write contract. The executor
+    retains final authority: it may reject an already human-approved request.
+    """
+
+    def execute_action(self, request: ActionRequest) -> ExecutionResult:  # pragma: no cover - protocol
+        ...
+
+
+@dataclass(frozen=True)
+class AuditEntry:
+    seq: int
+    request_id: str
+    event: str
+    from_state: Optional[str]
+    to_state: str
+    modality: str
+    at: float
+    detail: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "seq": self.seq,
+            "request_id": self.request_id,
+            "event": self.event,
+            "from_state": self.from_state,
+            "to_state": self.to_state,
+            "modality": self.modality,
+            "at": self.at,
+            "detail": self.detail,
+        }
+
+
+@dataclass
+class _Tracked:
+    request: ActionRequest
+    state: RequestState
+    created_at: float
+    deadline: Optional[float]
+    result: Optional[ExecutionResult] = None
+
+
+class ControlledRequestManager:
+    """State machine and audit trail for controlled write requests.
+
+    Read-only situation data never flows through here. The manager holds pending
+    requests, enforces the approve/deny/cancel/timeout transitions, and dispatches
+    only human-approved requests to an external executor. A clock is injected so
+    timeout behaviour is deterministic under test.
+    """
+
+    def __init__(
+        self,
+        *,
+        dry_run: bool = False,
+        default_timeout_seconds: Optional[float] = 120.0,
+        clock: Optional[Callable[[], float]] = None,
+    ) -> None:
+        self.dry_run = bool(dry_run)
+        self.default_timeout_seconds = default_timeout_seconds
+        self._clock = clock or time.monotonic
+        self._tracked: Dict[str, _Tracked] = {}
+        self._audit: List[AuditEntry] = []
+
+    # -- introspection --------------------------------------------------------
+
+    @property
+    def audit_log(self) -> List[Dict[str, Any]]:
+        return [entry.to_dict() for entry in self._audit]
+
+    def state_of(self, request_id: str) -> RequestState:
+        return self._require(request_id).state
+
+    def result_of(self, request_id: str) -> Optional[ExecutionResult]:
+        return self._require(request_id).result
+
+    def pending_ids(self) -> List[str]:
+        self._expire_overdue()
+        return [rid for rid, t in self._tracked.items() if t.state == RequestState.PENDING_APPROVAL]
+
+    # -- transitions ----------------------------------------------------------
+
+    def submit(self, request: ActionRequest, *, timeout_seconds: Optional[float] = "default") -> RequestState:
+        if request.request_id in self._tracked:
+            raise RequestError(f"duplicate request_id: {request.request_id}")
+        now = self._clock()
+        window = self.default_timeout_seconds if timeout_seconds == "default" else timeout_seconds
+        deadline = None if window is None else now + float(window)
+        self._tracked[request.request_id] = _Tracked(
+            request=request,
+            state=RequestState.PENDING_APPROVAL,
+            created_at=now,
+            deadline=deadline,
+        )
+        self._record(request.request_id, "submit", None, RequestState.PENDING_APPROVAL, request.requested_by_modality)
+        return RequestState.PENDING_APPROVAL
+
+    def approve(self, request_id: str, modality: str) -> RequestState:
+        return self._decide(request_id, modality, approve=True)
+
+    def deny(self, request_id: str, modality: str, *, detail: Optional[str] = None) -> RequestState:
+        return self._decide(request_id, modality, approve=False, detail=detail)
+
+    def _decide(self, request_id: str, modality: str, *, approve: bool, detail: Optional[str] = None) -> RequestState:
+        tracked = self._require(request_id)
+        self._expire_overdue()
+        tracked = self._require(request_id)
+        if tracked.state != RequestState.PENDING_APPROVAL:
+            raise RequestError(
+                f"cannot {'approve' if approve else 'deny'} request in state {tracked.state.value}"
+            )
+        target = RequestState.APPROVED if approve else RequestState.DENIED
+        prev = tracked.state
+        tracked.state = target
+        self._record(request_id, "approve" if approve else "deny", prev, target, modality, detail)
+        return target
+
+    def cancel(self, request_id: str, modality: str, *, detail: Optional[str] = None) -> RequestState:
+        tracked = self._require(request_id)
+        if tracked.state in _TERMINAL:
+            raise RequestError(f"cannot cancel request in terminal state {tracked.state.value}")
+        # Cancellation is allowed while pending or after approval but before dispatch.
+        prev = tracked.state
+        tracked.state = RequestState.CANCELLED
+        self._record(request_id, "cancel", prev, RequestState.CANCELLED, modality, detail)
+        return RequestState.CANCELLED
+
+    def dispatch(self, request_id: str, executor: Optional[ActionExecutor], *, modality: str = "system") -> RequestState:
+        """Send an approved request to the external executor.
+
+        Only APPROVED requests dispatch. Under dry_run the executor is not called.
+        The executor may still reject an approved request; external systems keep
+        final authority.
+        """
+        tracked = self._require(request_id)
+        if tracked.state != RequestState.APPROVED:
+            raise RequestError(f"cannot dispatch request in state {tracked.state.value}")
+
+        if self.dry_run:
+            result = ExecutionResult(ok=True, detail="dry_run")
+            tracked.result = result
+            tracked.state = RequestState.COMPLETED
+            self._record(request_id, "dispatch_dry_run", RequestState.APPROVED, RequestState.COMPLETED, modality, "dry_run")
+            return tracked.state
+
+        if executor is None:
+            raise RequestError("no executor supplied for a live dispatch")
+
+        result = executor.execute_action(tracked.request)
+        tracked.result = result
+        if result.ok:
+            tracked.state = RequestState.COMPLETED
+            self._record(request_id, "dispatch", RequestState.APPROVED, RequestState.COMPLETED, modality, result.detail)
+        else:
+            tracked.state = RequestState.FAILED
+            event = "executor_rejected" if result.rejected_by_executor else "dispatch_failed"
+            self._record(request_id, event, RequestState.APPROVED, RequestState.FAILED, modality, result.detail)
+        return tracked.state
+
+    def poll_timeouts(self) -> List[str]:
+        """Expire any pending request past its deadline; return the affected ids."""
+        return self._expire_overdue()
+
+    # -- internals ------------------------------------------------------------
+
+    def _expire_overdue(self) -> List[str]:
+        now = self._clock()
+        expired: List[str] = []
+        for rid, tracked in self._tracked.items():
+            if (
+                tracked.state == RequestState.PENDING_APPROVAL
+                and tracked.deadline is not None
+                and now >= tracked.deadline
+            ):
+                tracked.state = RequestState.TIMED_OUT
+                self._record(rid, "timeout", RequestState.PENDING_APPROVAL, RequestState.TIMED_OUT, "system")
+                expired.append(rid)
+        return expired
+
+    def _require(self, request_id: str) -> _Tracked:
+        tracked = self._tracked.get(request_id)
+        if tracked is None:
+            raise RequestError(f"unknown request_id: {request_id}")
+        return tracked
+
+    def _record(
+        self,
+        request_id: str,
+        event: str,
+        from_state: Optional[RequestState],
+        to_state: RequestState,
+        modality: str,
+        detail: Optional[str] = None,
+    ) -> None:
+        self._audit.append(
+            AuditEntry(
+                seq=len(self._audit) + 1,
+                request_id=request_id,
+                event=event,
+                from_state=from_state.value if from_state else None,
+                to_state=to_state.value,
+                modality=str(modality),
+                at=self._clock(),
+                detail=detail,
+            )
+        )

--- a/docs/request-contract.md
+++ b/docs/request-contract.md
@@ -1,0 +1,88 @@
+# Controlled request / approval contract
+
+Version: `babbly.action-request.v1`. Implemented in `babbly/core/request.py`
+(issue #18).
+
+This is the **only** supported path by which Babbly submits a write-capable or
+state-changing request to an external executor. It is separate from the
+read-only `SituationSnapshot` / Recommendation model and preserves explicit
+human authority and an audit trail.
+
+## Why it is separate from the Situation Model
+
+The Situation Model and Recommendations are read-only/advisory. A recommendation
+is never replayed as a command, and a read-only situation adapter can never
+satisfy the write contract: the executor interface uses a distinct method
+(`ActionExecutor.execute_action`), so a situation source that only exposes
+`collect()` is not an executor.
+
+`ActionRequest` carries an action **identifier** and normalized parameters — no
+shell string, no credentials, no authority grant.
+
+## State machine
+
+```text
+                submit
+                  v
+          PENDING_APPROVAL ──approve──> APPROVED ──dispatch──> COMPLETED
+             │  │  │                       │                     
+             │  │  └──deny──> DENIED        └──dispatch(fail /    ──> FAILED
+             │  │                                 executor reject)
+             │  └──cancel──> CANCELLED      (cancel before dispatch also allowed)
+             └──timeout──> TIMED_OUT
+```
+
+- `PENDING_APPROVAL` → `APPROVED` | `DENIED` | `CANCELLED` | `TIMED_OUT`
+- `APPROVED` → `COMPLETED` | `FAILED` | `CANCELLED` (before dispatch)
+- `DENIED`, `CANCELLED`, `TIMED_OUT`, `COMPLETED`, `FAILED` are terminal.
+
+Approval is always an explicit, separate human step. `RiskClass`
+(low/medium/high) is advisory metadata for surfaces; it never removes the
+approval requirement.
+
+## Human authority and external authority
+
+- A request only dispatches after a human `approve`.
+- The external executor keeps **final** authority: it may reject an already
+  human-approved request (`ExecutionResult(ok=False, rejected_by_executor=True)`
+  → `FAILED`). Approval by Babbly is necessary but not sufficient.
+- Under `dry_run`, an approved request completes without calling the executor,
+  for field tuning.
+
+## Modality switching
+
+Requests are keyed by `request_id` and carry a stable `correlation_id` and
+`audit_id`. A request submitted from voice can be approved or denied from the
+web/EUD surface without losing correlation; every transition records the acting
+`modality`. Confirmation policy is identical across surfaces.
+
+## Timeouts
+
+Each request may carry an approval window (`default_timeout_seconds`). Once the
+deadline passes, `poll_timeouts()` (and any approve/deny attempt) moves a still
+`PENDING_APPROVAL` request to `TIMED_OUT`. The clock is injectable, so timeout
+behaviour is deterministic under test.
+
+## Audit record
+
+Every transition appends an `AuditEntry` with `seq`, `request_id`, `event`,
+`from_state`, `to_state`, `modality`, `at`, and optional `detail`. The audit log
+therefore contains the request, the approval decision, the result, and modality
+metadata for the full lifecycle.
+
+## Relationship to the canonical intent runtime
+
+`OperatorIntentRuntime` today stops registered `operation.run` at
+`confirmation_required` and represents DRY_RUN; it does not itself perform
+external writes. Wiring a confirmed operation into a `ControlledRequestManager`
+request (and an Azazel-Edge `ActionExecutor`) is the integration point for the
+future "M.I.O, isolate the target" flow, which must still end at Azazel-Edge's
+deterministic decision authority.
+
+## Safety invariants
+
+- `SituationSnapshot` / Recommendation stay read-only/advisory.
+- no observed `current_action` is replayed as a Babbly command.
+- external systems retain final authority for their own actions.
+- visual and voice surfaces apply identical confirmation policy.
+- no arbitrary shell string is a request contract.

--- a/tests/test_controlled_request.py
+++ b/tests/test_controlled_request.py
@@ -1,0 +1,179 @@
+import pytest
+
+from babbly.core.request import (
+    ActionExecutor,
+    ActionRequest,
+    ControlledRequestManager,
+    ExecutionResult,
+    RequestError,
+    RequestState,
+    RiskClass,
+)
+
+
+class FakeClock:
+    def __init__(self, start: float = 1000.0) -> None:
+        self.now = float(start)
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += float(seconds)
+
+
+class RecordingExecutor:
+    def __init__(self, result: ExecutionResult) -> None:
+        self.result = result
+        self.calls = []
+
+    def execute_action(self, request: ActionRequest) -> ExecutionResult:
+        self.calls.append(request.request_id)
+        return self.result
+
+
+class ReadOnlyAdapter:
+    """Stands in for a situation source: it can only be collected, not executed."""
+
+    def collect(self):
+        return {}
+
+
+def _request(**kw) -> ActionRequest:
+    params = dict(action="isolate.target", parameters={"scope": "host"}, target_ref="target-A",
+                  requested_by_modality="voice", risk_class=RiskClass.HIGH)
+    params.update(kw)
+    return ActionRequest(**params)
+
+
+def _manager(**kw) -> ControlledRequestManager:
+    kw.setdefault("clock", FakeClock())
+    return ControlledRequestManager(**kw)
+
+
+def test_submit_creates_pending_and_audits():
+    mgr = _manager()
+    req = _request()
+    assert mgr.submit(req) is RequestState.PENDING_APPROVAL
+    assert mgr.state_of(req.request_id) is RequestState.PENDING_APPROVAL
+    assert mgr.pending_ids() == [req.request_id]
+    assert mgr.audit_log[0]["event"] == "submit"
+    assert mgr.audit_log[0]["modality"] == "voice"
+
+
+def test_request_contract_carries_no_shell_string():
+    payload = _request().to_dict()
+    assert payload["schema_version"] == "babbly.action-request.v1"
+    assert "command" not in payload and "shell" not in payload
+    assert payload["action"] == "isolate.target"
+
+
+def test_cross_modality_approval_preserves_correlation():
+    mgr = _manager()
+    req = _request(requested_by_modality="voice")
+    mgr.submit(req)
+    assert mgr.approve(req.request_id, "web") is RequestState.APPROVED
+    events = {(e["event"], e["modality"]) for e in mgr.audit_log}
+    assert ("submit", "voice") in events
+    assert ("approve", "web") in events
+    # correlation identity is the request's own, unchanged by the modality switch
+    assert req.correlation_id  # stable object identity, never reassigned
+
+
+def test_deny_is_terminal():
+    mgr = _manager()
+    req = _request()
+    mgr.submit(req)
+    assert mgr.deny(req.request_id, "web", detail="operator refused") is RequestState.DENIED
+    with pytest.raises(RequestError):
+        mgr.approve(req.request_id, "web")
+
+
+def test_cancel_pending_and_after_approval():
+    mgr = _manager()
+    r1, r2 = _request(), _request()
+    mgr.submit(r1)
+    assert mgr.cancel(r1.request_id, "voice") is RequestState.CANCELLED
+    mgr.submit(r2)
+    mgr.approve(r2.request_id, "web")
+    assert mgr.cancel(r2.request_id, "web") is RequestState.CANCELLED
+    with pytest.raises(RequestError):
+        mgr.cancel(r2.request_id, "web")  # already terminal
+
+
+def test_timeout_expires_pending_and_blocks_approval():
+    clock = FakeClock()
+    mgr = ControlledRequestManager(clock=clock, default_timeout_seconds=30.0)
+    req = _request()
+    mgr.submit(req)
+    clock.advance(31.0)
+    assert mgr.poll_timeouts() == [req.request_id]
+    assert mgr.state_of(req.request_id) is RequestState.TIMED_OUT
+    with pytest.raises(RequestError):
+        mgr.approve(req.request_id, "web")
+    assert mgr.audit_log[-1]["event"] == "timeout"
+
+
+def test_no_timeout_when_window_disabled():
+    clock = FakeClock()
+    mgr = ControlledRequestManager(clock=clock, default_timeout_seconds=None)
+    req = _request()
+    mgr.submit(req)
+    clock.advance(10_000.0)
+    assert mgr.poll_timeouts() == []
+    assert mgr.state_of(req.request_id) is RequestState.PENDING_APPROVAL
+
+
+def test_dispatch_requires_approval():
+    mgr = _manager()
+    req = _request()
+    mgr.submit(req)
+    with pytest.raises(RequestError):
+        mgr.dispatch(req.request_id, RecordingExecutor(ExecutionResult(ok=True)))
+
+
+def test_approved_request_dispatches_to_executor():
+    mgr = _manager()
+    req = _request()
+    mgr.submit(req)
+    mgr.approve(req.request_id, "web")
+    executor = RecordingExecutor(ExecutionResult(ok=True, external_ref="edge-42"))
+    assert mgr.dispatch(req.request_id, executor) is RequestState.COMPLETED
+    assert executor.calls == [req.request_id]
+    assert mgr.result_of(req.request_id).external_ref == "edge-42"
+
+
+def test_external_executor_retains_final_authority():
+    mgr = _manager()
+    req = _request()
+    mgr.submit(req)
+    mgr.approve(req.request_id, "web")
+    executor = RecordingExecutor(ExecutionResult(ok=False, rejected_by_executor=True, detail="policy denied"))
+    assert mgr.dispatch(req.request_id, executor) is RequestState.FAILED
+    assert mgr.audit_log[-1]["event"] == "executor_rejected"
+
+
+def test_dry_run_does_not_call_executor():
+    mgr = _manager(dry_run=True)
+    req = _request()
+    mgr.submit(req)
+    mgr.approve(req.request_id, "web")
+    executor = RecordingExecutor(ExecutionResult(ok=True))
+    assert mgr.dispatch(req.request_id, executor) is RequestState.COMPLETED
+    assert executor.calls == []
+    assert mgr.result_of(req.request_id).detail == "dry_run"
+
+
+def test_read_only_adapter_cannot_satisfy_write_contract():
+    assert isinstance(RecordingExecutor(ExecutionResult(ok=True)), ActionExecutor)
+    assert not isinstance(ReadOnlyAdapter(), ActionExecutor)
+
+
+def test_duplicate_and_unknown_request_ids():
+    mgr = _manager()
+    req = _request()
+    mgr.submit(req)
+    with pytest.raises(RequestError):
+        mgr.submit(req)
+    with pytest.raises(RequestError):
+        mgr.state_of("nope")


### PR DESCRIPTION
## Summary
Implements #18. Adds `babbly.action-request.v1`: the **only** supported path for write-capable/state-changing requests to an external executor, kept fully separate from the read-only `SituationSnapshot`/Recommendation model.

- `ActionRequest`: action **identifier** + normalized parameters, target/context binding, `RiskClass`, correlation + audit IDs. No shell string, no credentials, no authority grant.
- `ControlledRequestManager`: state machine `PENDING_APPROVAL → APPROVED/DENIED/CANCELLED/TIMED_OUT` and `APPROVED → COMPLETED/FAILED`, injectable clock for deterministic timeouts, full audit trail (event, from/to state, modality, time).
- Approval is always an explicit human step. The `ActionExecutor` protocol (`execute_action`) is distinct from read-only situation adapters (`collect()`), so a read-only adapter cannot satisfy the write contract. The executor keeps **final** authority and may reject an approved request; `dry_run` completes without calling it.
- A request submitted from one modality can be approved/denied from another without losing correlation.

Docs: `docs/request-contract.md`.

## Acceptance criteria (issue #18)
- [x] documented request state machine
- [x] deterministic tests for approve/deny/cancel/timeout paths
- [x] pending approval initiated in one modality, completed/denied in another without losing correlation
- [x] audit record contains request, approval decision, result, and modality metadata
- [x] read-only adapter interfaces cannot accidentally satisfy the write contract
- [x] no arbitrary shell string as the request contract; Situation Model stays read-only

## Validation
- `python -m pytest -q tests` → 107 passed (was 94; +13).
- `python -m compileall -q babbly tools tests` → OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)