### PR TITLE
feat(bench): human-factors benchmark protocol, fixtures, and evaluator (#21)

### DIFF
--- a/benchmarks/example_human_factors_results.json
+++ b/benchmarks/example_human_factors_results.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "r-laptop-1", "condition": "laptop_cli", "task_id": "status-check",
+    "completed": true, "completion_time_s": 42.0, "intent_attempts": 3, "intent_correct": 3,
+    "false_executions": 0, "clarifications": 0, "time_to_important_info_s": 18.0,
+    "eyes_on_device_s": 40.0, "hands_on_device_s": 38.0, "workload": 45.0
+  },
+  {
+    "id": "r-laptop-2", "condition": "laptop_cli", "task_id": "confirm-operation",
+    "completed": true, "completion_time_s": 55.0, "intent_attempts": 4, "intent_correct": 4,
+    "false_executions": 0, "clarifications": 1, "time_to_important_info_s": 20.0,
+    "eyes_on_device_s": 52.0, "hands_on_device_s": 50.0, "workload": 52.0
+  },
+  {
+    "id": "r-hybrid-1", "condition": "hybrid_voice", "task_id": "status-check",
+    "completed": true, "completion_time_s": 30.0, "intent_attempts": 2, "intent_correct": 2,
+    "false_executions": 0, "clarifications": 0, "time_to_important_info_s": 8.0,
+    "eyes_on_device_s": 12.0, "hands_on_device_s": 6.0, "mode_switches": 1,
+    "mode_switch_continuity_errors": 0, "workload": 40.0
+  },
+  {
+    "id": "r-hybrid-2", "condition": "hybrid_voice", "task_id": "confirm-operation",
+    "completed": true, "completion_time_s": 44.0, "intent_attempts": 3, "intent_correct": 3,
+    "false_executions": 0, "clarifications": 1, "time_to_important_info_s": 10.0,
+    "eyes_on_device_s": 16.0, "hands_on_device_s": 9.0, "mode_switches": 1,
+    "mode_switch_continuity_errors": 0, "workload": 47.0
+  },
+  {
+    "id": "r-eyesfree-1", "condition": "eyes_free", "task_id": "status-check",
+    "completed": true, "completion_time_s": 34.0, "intent_attempts": 3, "intent_correct": 2,
+    "false_executions": 0, "clarifications": 1, "time_to_important_info_s": 9.0,
+    "eyes_on_device_s": 2.0, "hands_on_device_s": 1.0, "mode_switches": 2,
+    "mode_switch_continuity_errors": 0, "workload": 55.0
+  },
+  {
+    "id": "r-eyesfree-2", "condition": "eyes_free", "task_id": "confirm-operation",
+    "completed": false, "completion_time_s": 60.0, "intent_attempts": 4, "intent_correct": 3,
+    "false_executions": 0, "clarifications": 2, "time_to_important_info_s": 12.0,
+    "eyes_on_device_s": 3.0, "hands_on_device_s": 2.0, "mode_switches": 1,
+    "mode_switch_continuity_errors": 1, "workload": 68.0
+  }
+]

--- a/benchmarks/human_factors_scenarios.json
+++ b/benchmarks/human_factors_scenarios.json
@@ -1,0 +1,26 @@
+[
+  {
+    "task_id": "status-check",
+    "goal": "Determine the current situation status and the highest-priority recommendation.",
+    "equivalent_across_conditions": true,
+    "success_criteria": "Operator correctly reports the status level and the top recommended action.",
+    "important_info": "situation status + top recommendation",
+    "notes": "Measures time-to-important-information and eyes-on-device for a read-only query."
+  },
+  {
+    "task_id": "confirm-operation",
+    "goal": "Bring a registered operation to a pending confirmation and make an explicit approve/deny decision.",
+    "equivalent_across_conditions": true,
+    "success_criteria": "Correct operation reaches confirmation and the intended decision is recorded; no false execution.",
+    "important_info": "pending confirmation target + operation",
+    "notes": "Measures intent accuracy, false-execution rate, and clarification rate under each attention mode."
+  },
+  {
+    "task_id": "mode-switch-continuity",
+    "goal": "Begin a task visually, then continue and complete it eyes-free after switching attention mode.",
+    "equivalent_across_conditions": false,
+    "success_criteria": "Task target, context, and any pending confirmation survive the modality/mode switch.",
+    "important_info": "current target + pending confirmation",
+    "notes": "Babbly conditions only; measures mode-switch continuity errors and hands-on-device time."
+  }
+]

--- a/docs/human-factors-benchmark.md
+++ b/docs/human-factors-benchmark.md
@@ -1,0 +1,65 @@
+# Human-factors benchmark
+
+Issue #21. Babbly's concept is judged by whether it **reduces operator attention
+captured by the computing device while preserving correctness, control, and task
+continuity** — not by ASR accuracy alone. This document defines the protocol and
+fixtures; `tools/evaluate_human_factors.py` turns recorded runs into statistics.
+
+## Conditions
+
+Equivalent authorized lab tasks are run under four conditions:
+
+1. `laptop_cli` — conventional laptop/CLI operation (baseline)
+2. `visual_eud` — visual-only smartphone/EUD operation
+3. `hybrid_voice` — hybrid visual + voice Babbly operation
+4. `eyes_free` — eyes-free Babbly operation
+
+The baseline is `laptop_cli`; reductions are reported relative to it.
+
+## Scenarios
+
+`benchmarks/human_factors_scenarios.json` defines task goals that are equivalent
+across conditions (a read-only status check, an operation that must reach an
+explicit confirmation, and a Babbly-only mode-switch continuity task). Use the
+same task goals for every condition so results are comparable.
+
+## Measurements
+
+Each run is one record (`benchmarks/example_human_factors_results.json` shows the
+shape). Required per record:
+
+- `completed`, `completion_time_s`
+- `intent_attempts`, `intent_correct`, `false_executions`, `clarifications`
+- `eyes_on_device_s`, `hands_on_device_s`
+
+Optional: `time_to_important_info_s`, `mode_switches`,
+`mode_switch_continuity_errors`, `workload` (e.g. NASA-TLX 0–100).
+
+## Evaluation
+
+```bash
+python tools/evaluate_human_factors.py results/human-factors.json
+python tools/evaluate_human_factors.py results/human-factors.json --json
+```
+
+Per condition it reports task completion rate, completion time, intent accuracy,
+false-execution rate, clarification rate, time-to-important-information,
+eyes-on-device and hands-on-device time, mode-switch continuity error rate, and
+workload. It then compares each Babbly condition against the laptop baseline for
+eyes-on-device, hands-on-device, and completion time.
+
+## Reporting honestly
+
+- Results must include the raw records plus the summary statistics.
+- Conditions with fewer than three samples, or a missing baseline, are flagged in
+  `limitations` and must be treated as indicative only.
+- Failures and limitations are reported, not hidden. Final project claims about
+  situational-awareness preservation must cite measured results from this
+  protocol, not impressions.
+
+## Scope note
+
+The evaluator and fixtures are deterministic and ready now. The measured results
+require human runs on the visual/hybrid/eyes-free workflows (#17 is ready; the
+forearm field prototype is #20), so recorded numbers are produced during that
+field work.

--- a/tests/test_human_factors_evaluator.py
+++ b/tests/test_human_factors_evaluator.py
@@ -1,0 +1,87 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.evaluate_human_factors import evaluate
+
+
+def _rec(rid, condition, **kw):
+    base = dict(
+        id=rid, condition=condition, task_id="t", completed=True,
+        completion_time_s=40.0, intent_attempts=4, intent_correct=4,
+        false_executions=0, clarifications=0, eyes_on_device_s=40.0, hands_on_device_s=38.0,
+    )
+    base.update(kw)
+    return base
+
+
+def test_per_condition_summary_and_rates():
+    records = [
+        _rec("a", "laptop_cli", intent_attempts=4, intent_correct=3, false_executions=1, clarifications=2, eyes_on_device_s=40.0),
+        _rec("b", "laptop_cli", completed=False, eyes_on_device_s=50.0),
+    ]
+    summary, _ = evaluate(records)
+    cli = summary["per_condition"]["laptop_cli"]
+    assert cli["n"] == 2
+    assert cli["task_completion_rate"] == 0.5
+    # intent accuracy = (3+4)/(4+4) = 0.875
+    assert cli["intent_accuracy"] == pytest.approx(0.875)
+    # false-execution rate = 1 / 8 attempts
+    assert cli["false_execution_rate"] == pytest.approx(0.125)
+    assert cli["total_false_executions"] == 1
+    # completion time only over completed tasks
+    assert cli["mean_completion_time_s"] == 40.0
+    assert cli["mean_eyes_on_device_s"] == 45.0
+
+
+def test_comparison_reports_eyes_on_device_reduction():
+    records = [
+        _rec("base", "laptop_cli", eyes_on_device_s=40.0, hands_on_device_s=40.0, completion_time_s=50.0),
+        _rec("hy", "hybrid_voice", eyes_on_device_s=10.0, hands_on_device_s=8.0, completion_time_s=40.0),
+    ]
+    summary, _ = evaluate(records)
+    cmp = summary["comparison_vs_baseline"]["hybrid_voice"]
+    assert cmp["eyes_on_device_s"]["delta"] == -30.0
+    assert cmp["eyes_on_device_s"]["pct_change"] == pytest.approx(-75.0)
+    assert cmp["completion_time_s"]["delta"] == -10.0
+
+
+def test_mode_switch_continuity_error_rate():
+    records = [
+        _rec("m1", "eyes_free", mode_switches=2, mode_switch_continuity_errors=1),
+        _rec("m2", "eyes_free", mode_switches=2, mode_switch_continuity_errors=0),
+    ]
+    summary, _ = evaluate(records)
+    assert summary["per_condition"]["eyes_free"]["mode_switch_continuity_error_rate"] == pytest.approx(0.25)
+
+
+def test_limitations_flag_small_samples_and_missing_baseline():
+    records = [_rec("h", "hybrid_voice")]
+    summary, _ = evaluate(records)
+    assert any("no baseline" in item for item in summary["limitations"])
+    assert any("hybrid_voice: only 1 sample" in item for item in summary["limitations"])
+    assert summary["comparison_vs_baseline"] == {}
+
+
+def test_strict_validation():
+    with pytest.raises(ValueError):
+        evaluate([_rec("x", "laptop_cli", completed="yes")])  # string bool
+    with pytest.raises(ValueError):
+        evaluate([_rec("x", "bogus_condition")])
+    with pytest.raises(ValueError):
+        evaluate([_rec("x", "laptop_cli", intent_attempts=1, intent_correct=2)])  # correct > attempts
+    with pytest.raises(ValueError):
+        evaluate([_rec("x", "laptop_cli"), _rec("x", "laptop_cli")])  # duplicate id
+    with pytest.raises(ValueError):
+        evaluate([_rec("x", "laptop_cli", eyes_on_device_s=-1.0)])  # negative
+
+
+def test_example_fixture_is_valid_and_evaluates():
+    path = Path("benchmarks/example_human_factors_results.json")
+    records = json.loads(path.read_text(encoding="utf-8"))
+    summary, _ = evaluate(records)
+    assert summary["total_records"] == len(records)
+    assert "hybrid_voice" in summary["conditions_present"]
+    # hybrid/eyes-free should show reduced eyes-on-device vs the laptop baseline
+    assert summary["comparison_vs_baseline"]["eyes_free"]["eyes_on_device_s"]["delta"] < 0

--- a/tools/evaluate_human_factors.py
+++ b/tools/evaluate_human_factors.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Evaluate human-factors benchmark records for situational-awareness preservation.
+
+Babbly's concept is judged by whether it reduces operator attention captured by
+the computing device while preserving correctness and control (issue #21), not
+by ASR accuracy alone. This tool turns raw per-task session records into
+per-condition summary statistics and a comparison against the laptop/CLI
+baseline. The human runs produce the records; this evaluator is deterministic.
+"""
+
+import argparse
+import json
+from pathlib import Path
+from statistics import mean, median
+
+
+CONDITIONS = ("laptop_cli", "visual_eud", "hybrid_voice", "eyes_free")
+BASELINE = "laptop_cli"
+MIN_SAMPLES = 3
+
+_REQUIRED_NUMERIC = (
+    "completion_time_s",
+    "eyes_on_device_s",
+    "hands_on_device_s",
+)
+_REQUIRED_INT = (
+    "intent_attempts",
+    "intent_correct",
+    "false_executions",
+    "clarifications",
+)
+_OPTIONAL_NUMERIC = ("time_to_important_info_s", "workload")
+_OPTIONAL_INT = ("mode_switches", "mode_switch_continuity_errors")
+
+
+def load_json(path):
+    with open(path, "r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, list):
+        raise ValueError(f"{path} must contain a JSON array")
+    return data
+
+
+def _bool(value, field, rid):
+    if type(value) is not bool:
+        raise ValueError(f"{rid}: {field} must be a JSON boolean")
+    return value
+
+
+def _int(value, field, rid):
+    if type(value) is not int or type(value) is bool or value < 0:
+        raise ValueError(f"{rid}: {field} must be a non-negative integer")
+    return value
+
+
+def _num(value, field, rid):
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value < 0:
+        raise ValueError(f"{rid}: {field} must be a non-negative number")
+    return float(value)
+
+
+def _avg(records, field):
+    values = [r[field] for r in records if r.get(field) is not None]
+    return mean(values) if values else None
+
+
+def _rate(records, numerator, denominator):
+    denom = sum(r[denominator] for r in records)
+    if denom == 0:
+        return None
+    return sum(r[numerator] for r in records) / denom
+
+
+def _validate(records):
+    seen = set()
+    clean = []
+    for raw in records:
+        rid = str(raw.get("id") or "").strip()
+        if not rid:
+            raise ValueError("record is missing id")
+        if rid in seen:
+            raise ValueError(f"duplicate record id: {rid}")
+        seen.add(rid)
+
+        condition = raw.get("condition")
+        if condition not in CONDITIONS:
+            raise ValueError(f"{rid}: condition must be one of {CONDITIONS}")
+
+        record = {"id": rid, "condition": condition, "task_id": str(raw.get("task_id") or "")}
+        record["completed"] = _bool(raw.get("completed"), "completed", rid)
+        for field in _REQUIRED_NUMERIC:
+            record[field] = _num(raw.get(field), field, rid)
+        for field in _REQUIRED_INT:
+            record[field] = _int(raw.get(field), field, rid)
+        if record["intent_correct"] > record["intent_attempts"]:
+            raise ValueError(f"{rid}: intent_correct cannot exceed intent_attempts")
+        for field in _OPTIONAL_NUMERIC:
+            record[field] = None if raw.get(field) is None else _num(raw.get(field), field, rid)
+        for field in _OPTIONAL_INT:
+            record[field] = None if raw.get(field) is None else _int(raw.get(field), field, rid)
+        clean.append(record)
+    return clean
+
+
+def _summarize_condition(records):
+    completed = [r for r in records if r["completed"]]
+    switches = sum(r["mode_switches"] or 0 for r in records)
+    switch_errors = sum(r["mode_switch_continuity_errors"] or 0 for r in records)
+    return {
+        "n": len(records),
+        "task_completion_rate": len(completed) / len(records) if records else None,
+        "mean_completion_time_s": mean([r["completion_time_s"] for r in completed]) if completed else None,
+        "median_completion_time_s": median([r["completion_time_s"] for r in completed]) if completed else None,
+        "intent_accuracy": _rate(records, "intent_correct", "intent_attempts"),
+        "false_execution_rate": _rate(records, "false_executions", "intent_attempts"),
+        "total_false_executions": sum(r["false_executions"] for r in records),
+        "clarification_rate": _rate(records, "clarifications", "intent_attempts"),
+        "mean_time_to_important_info_s": _avg(records, "time_to_important_info_s"),
+        "mean_eyes_on_device_s": _avg(records, "eyes_on_device_s"),
+        "mean_hands_on_device_s": _avg(records, "hands_on_device_s"),
+        "mode_switch_continuity_error_rate": (switch_errors / switches) if switches else None,
+        "mean_workload": _avg(records, "workload"),
+    }
+
+
+def _reduction(baseline, value):
+    if baseline is None or value is None:
+        return None
+    delta = value - baseline
+    pct = (delta / baseline * 100.0) if baseline else None
+    return {"delta": delta, "pct_change": pct}
+
+
+def evaluate(records):
+    clean = _validate(records)
+    by_condition = {c: [r for r in clean if r["condition"] == c] for c in CONDITIONS}
+    per_condition = {c: _summarize_condition(rs) for c, rs in by_condition.items() if rs}
+
+    comparison = {}
+    base = per_condition.get(BASELINE)
+    if base:
+        for condition, summary in per_condition.items():
+            if condition == BASELINE:
+                continue
+            comparison[condition] = {
+                "eyes_on_device_s": _reduction(base["mean_eyes_on_device_s"], summary["mean_eyes_on_device_s"]),
+                "hands_on_device_s": _reduction(base["mean_hands_on_device_s"], summary["mean_hands_on_device_s"]),
+                "completion_time_s": _reduction(base["mean_completion_time_s"], summary["mean_completion_time_s"]),
+            }
+
+    limitations = []
+    if BASELINE not in per_condition:
+        limitations.append(f"no baseline ({BASELINE}) records; comparison omitted")
+    for condition in CONDITIONS:
+        summary = per_condition.get(condition)
+        if summary is None:
+            limitations.append(f"no records for condition {condition}")
+        elif summary["n"] < MIN_SAMPLES:
+            limitations.append(f"{condition}: only {summary['n']} sample(s) (< {MIN_SAMPLES}); treat as indicative")
+
+    summary = {
+        "total_records": len(clean),
+        "conditions_present": sorted(per_condition),
+        "per_condition": per_condition,
+        "comparison_vs_baseline": comparison,
+        "limitations": limitations,
+    }
+    return summary, per_condition
+
+
+def _fmt(value, spec="{:.2f}"):
+    return "n/a" if value is None else spec.format(value)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Evaluate human-factors benchmark records")
+    parser.add_argument("results", help="JSON array of per-task session records")
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    args = parser.parse_args()
+
+    summary, _rows = evaluate(load_json(Path(args.results)))
+
+    if args.json:
+        print(json.dumps(summary, ensure_ascii=False, indent=2))
+        return
+
+    print(f"records: {summary['total_records']}  conditions: {', '.join(summary['conditions_present'])}")
+    for condition, s in summary["per_condition"].items():
+        print(f"\n[{condition}] n={s['n']}")
+        print(f"  completion rate: {_fmt(s['task_completion_rate'], '{:.1%}')}")
+        print(f"  mean completion time s: {_fmt(s['mean_completion_time_s'])}")
+        print(f"  intent accuracy: {_fmt(s['intent_accuracy'], '{:.1%}')}")
+        print(f"  false-execution rate: {_fmt(s['false_execution_rate'], '{:.3f}')}")
+        print(f"  clarification rate: {_fmt(s['clarification_rate'], '{:.3f}')}")
+        print(f"  mean eyes-on-device s: {_fmt(s['mean_eyes_on_device_s'])}")
+        print(f"  mean hands-on-device s: {_fmt(s['mean_hands_on_device_s'])}")
+        print(f"  mode-switch continuity error rate: {_fmt(s['mode_switch_continuity_error_rate'], '{:.3f}')}")
+        print(f"  mean workload: {_fmt(s['mean_workload'])}")
+    if summary["comparison_vs_baseline"]:
+        print(f"\nvs baseline ({BASELINE}):")
+        for condition, cmp in summary["comparison_vs_baseline"].items():
+            eyes = cmp["eyes_on_device_s"]
+            print(f"  {condition}: eyes-on-device {(_fmt(eyes['pct_change'], '{:+.1f}%') if eyes else 'n/a')}")
+    if summary["limitations"]:
+        print("\nlimitations:")
+        for item in summary["limitations"]:
+            print(f"  - {item}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Implements the software/tooling for #21: judge Babbly by the problem it targets — reducing operator attention captured by the device while preserving correctness and control — not ASR accuracy alone.

- `docs/human-factors-benchmark.md`: protocol over four conditions (`laptop_cli` baseline, `visual_eud`, `hybrid_voice`, `eyes_free`) with equivalent task goals.
- `benchmarks/human_factors_scenarios.json` + `example_human_factors_results.json`: scenario fixtures and the per-run record shape.
- `tools/evaluate_human_factors.py`: deterministic evaluator computing per-condition completion rate/time, intent accuracy, false-execution and clarification rates, time-to-important-info, eyes-on-device and hands-on-device time, mode-switch continuity error rate, and workload — plus reductions vs the laptop baseline. Small samples / missing baseline are flagged as `limitations`, not hidden.

## Acceptance criteria (issue #21)
- [x] benchmark protocol and fixtures/scenarios documented
- [x] baseline and Babbly conditions use equivalent task goals
- [x] results include raw measurements plus summary statistics (evaluator emits both; `--json`)
- [x] failures/limitations reported, not hidden (small-sample / missing-baseline flags)
- [~] final claims tied to measured results — the evaluator is ready; **measured numbers require human field runs** (#17 ready; forearm prototype #20). Issue kept open for those runs.

## Validation
- `python -m pytest -q tests` → 113 passed (+6 on this branch).
- `python -m compileall -q babbly tools tests` → OK.
- CLI smoke on the example fixture shows eyes-on-device −70%/−95% for hybrid/eyes-free vs baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)