### PR TITLE
feat(core): wire confirmed operation.run to controlled write dispatch (#18)

### DIFF
--- a/babbly/adapters/azazel_edge_action.py
+++ b/babbly/adapters/azazel_edge_action.py
@@ -1,0 +1,119 @@
+"""Write-capable Azazel-Edge action executor for the controlled request path.
+
+This is the counterpart to the read-only status transport. It implements the
+`ActionExecutor` contract (#18) by translating a Babbly `ActionRequest` into an
+action *proposal* envelope and POSTing it to Azazel-Edge. Babbly never decides
+the action itself: Azazel-Edge retains final, deterministic decision authority
+and may reject an already human-approved request.
+
+The executor is disabled by default (see `create_action_executor`) so standalone
+and read-only deployments gain no write path. There is no shell string anywhere
+in this contract.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Callable, Mapping, Optional
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+from babbly.core.request import ActionExecutor, ActionRequest, ExecutionResult
+
+
+ACTION_PROPOSAL_SCHEMA = "babbly.action-proposal.v1"
+
+_APPROVED = {"approved", "accepted", "allow", "allowed", "ok", "success"}
+_REJECTED = {"rejected", "denied", "deny", "blocked", "refused"}
+
+
+class AzazelEdgeActionError(RuntimeError):
+    """Raised when the Edge action surface cannot be reached or understood."""
+
+
+def translate_action_request(request: ActionRequest) -> dict:
+    """Translate an ActionRequest into the Edge action-proposal envelope."""
+    return {
+        "schema_version": ACTION_PROPOSAL_SCHEMA,
+        "action": request.action,
+        "parameters": dict(request.parameters),
+        "target": request.target_ref,
+        "context": request.context_ref,
+        "risk_class": request.risk_class.value,
+        "requested_by_modality": request.requested_by_modality,
+        "correlation_id": request.correlation_id,
+        "audit_id": request.audit_id,
+    }
+
+
+def interpret_edge_decision(payload: Mapping[str, Any]) -> ExecutionResult:
+    """Map an Edge decision response to an ExecutionResult.
+
+    Edge is authoritative. An unrecognized decision is treated as *not*
+    approved so the request fails closed rather than being assumed successful.
+    """
+    decision = str(payload.get("decision") or payload.get("status") or "").strip().lower()
+    detail = str(payload.get("detail") or payload.get("reason") or "")
+    external_ref = payload.get("external_ref") or payload.get("id")
+    external_ref = str(external_ref) if external_ref is not None else None
+    if decision in _APPROVED:
+        return ExecutionResult(ok=True, detail=detail, external_ref=external_ref)
+    rejected = decision in _REJECTED or decision != ""
+    return ExecutionResult(ok=False, detail=detail or f"edge decision: {decision or 'unknown'}",
+                           external_ref=external_ref, rejected_by_executor=rejected)
+
+
+class AzazelEdgeActionExecutor(ActionExecutor):
+    """POST an approved ActionRequest to Azazel-Edge and interpret its decision."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        token: Optional[str] = None,
+        path: str = "/api/action",
+        timeout_sec: float = 3.0,
+        max_response_bytes: int = 256 * 1024,
+        opener: Callable[..., Any] = urlopen,
+    ) -> None:
+        base = str(base_url or "").strip().rstrip("/")
+        parsed = urlparse(base)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("AZAZEL_EDGE_URL must be an http(s) URL")
+        self.url = base + "/" + str(path or "/api/action").lstrip("/")
+        self.token = str(token or "").strip()
+        self.timeout_sec = max(0.1, float(timeout_sec))
+        self.max_response_bytes = max(1024, int(max_response_bytes))
+        self.opener = opener
+
+    def execute_action(self, request: ActionRequest) -> ExecutionResult:
+        body = json.dumps(translate_action_request(request)).encode("utf-8")
+        headers = {"Accept": "application/json", "Content-Type": "application/json"}
+        if self.token:
+            headers["X-AZAZEL-TOKEN"] = self.token
+        http_request = Request(self.url, data=body, headers=headers, method="POST")
+
+        response = None
+        try:
+            response = self.opener(http_request, timeout=self.timeout_sec)
+            status = response.getcode() if hasattr(response, "getcode") else getattr(response, "status", 200)
+            if status is not None and int(status) >= 400:
+                return ExecutionResult(ok=False, detail=f"edge HTTP {status}", rejected_by_executor=False)
+            raw = response.read(self.max_response_bytes + 1)
+        except Exception as exc:  # transport failure is not an authoritative denial
+            return ExecutionResult(ok=False, detail=f"edge action request failed: {exc}", rejected_by_executor=False)
+        finally:
+            if response is not None:
+                close = getattr(response, "close", None)
+                if callable(close):
+                    close()
+
+        if len(raw) > self.max_response_bytes:
+            return ExecutionResult(ok=False, detail="edge action response exceeded size limit", rejected_by_executor=False)
+        try:
+            decoded = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return ExecutionResult(ok=False, detail="edge returned invalid JSON", rejected_by_executor=False)
+        if not isinstance(decoded, Mapping):
+            return ExecutionResult(ok=False, detail="edge action payload is not an object", rejected_by_executor=False)
+        return interpret_edge_decision(decoded)

--- a/babbly/adapters/factory.py
+++ b/babbly/adapters/factory.py
@@ -8,8 +8,10 @@ from pathlib import Path
 from typing import Mapping
 
 from babbly.adapters.azazel import AzazelAdapter
+from babbly.adapters.azazel_edge_action import AzazelEdgeActionExecutor
 from babbly.adapters.azazel_edge_transport import AzazelEdgeStatusProvider
 from babbly.core.engine import SituationEngine
+from babbly.core.request import RiskClass
 
 
 logger = logging.getLogger(__name__)
@@ -53,3 +55,50 @@ def create_situation_engine(config: Mapping[str, object]) -> SituationEngine:
             logger.warning("Azazel-Edge adapter configuration rejected: %s", exc)
 
     return SituationEngine(adapters)
+
+
+def parse_write_actions(config: Mapping[str, object]) -> dict:
+    """Read the operator-configured external write-action allowlist.
+
+    Accepts a list of action names (each defaults to HIGH risk) or a mapping of
+    name -> risk class. Empty/unset means no external write action exists, so a
+    confirmed operation stays at the registered-executor boundary.
+    """
+    raw = config.get("AZAZEL_EDGE_WRITE_ACTIONS")
+    actions: dict = {}
+    if isinstance(raw, Mapping):
+        for name, risk in raw.items():
+            try:
+                actions[str(name)] = RiskClass(str(risk))
+            except ValueError:
+                logger.warning("Ignoring write action %s with invalid risk class %r", name, risk)
+    elif isinstance(raw, (list, tuple)):
+        for name in raw:
+            if name:
+                actions[str(name)] = RiskClass.HIGH
+    return actions
+
+
+def create_action_executor(config: Mapping[str, object]):
+    """Build the controlled write executor, or None when the write path is off.
+
+    Disabled by default. Requires both `AZAZEL_EDGE_WRITE_ENABLED` and at least
+    one configured write action. A configuration error never grants authority;
+    the executor simply remains unavailable.
+    """
+    if not bool(config.get("AZAZEL_EDGE_WRITE_ENABLED", False)):
+        return None
+    if not parse_write_actions(config):
+        logger.warning("Azazel-Edge write enabled but no AZAZEL_EDGE_WRITE_ACTIONS configured; write path stays off")
+        return None
+    try:
+        return AzazelEdgeActionExecutor(
+            str(config.get("AZAZEL_EDGE_URL") or "http://127.0.0.1:8084"),
+            token=_load_edge_token(config),
+            path=str(config.get("AZAZEL_EDGE_ACTION_PATH") or "/api/action"),
+            timeout_sec=float(config.get("AZAZEL_EDGE_ACTION_TIMEOUT_SEC", 3.0)),
+            max_response_bytes=int(config.get("AZAZEL_EDGE_MAX_RESPONSE_BYTES", 256 * 1024)),
+        )
+    except (TypeError, ValueError) as exc:
+        logger.warning("Azazel-Edge action executor configuration rejected: %s", exc)
+        return None

--- a/babbly/core/operator_runtime.py
+++ b/babbly/core/operator_runtime.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Optional
 
+from typing import Mapping as _Mapping
+
 from babbly.core.attention import AttentionController, coerce_state
 from babbly.core.engine import SituationEngine
 from babbly.core.operator_intent import (
@@ -10,6 +12,12 @@ from babbly.core.operator_intent import (
     OperatorIntent,
     OperatorResult,
     SourceModality,
+)
+from babbly.core.request import (
+    ActionExecutor,
+    ActionRequest,
+    ControlledRequestManager,
+    RiskClass,
 )
 
 
@@ -32,11 +40,32 @@ class OperatorIntentRuntime:
         dry_run: bool = False,
         context: Optional[OperatorContext] = None,
         attention: Optional[AttentionController] = None,
+        request_manager: Optional[ControlledRequestManager] = None,
+        action_executor: Optional[ActionExecutor] = None,
+        write_actions: Optional[_Mapping[str, RiskClass]] = None,
     ) -> None:
         self.situation_engine = situation_engine or SituationEngine()
         self.dry_run = bool(dry_run)
         self.context = context or OperatorContext()
         self.attention = attention or AttentionController()
+        # Controlled write path (#18). Absent by default so a registered
+        # operation still stops at the registered-executor boundary. When both a
+        # manager and executor are provided, an operation named in write_actions
+        # is dispatched as a controlled external request after human approval.
+        self.request_manager = request_manager
+        self.action_executor = action_executor
+        self.write_actions = self._normalize_write_actions(write_actions)
+
+    @staticmethod
+    def _normalize_write_actions(
+        write_actions: Optional[_Mapping[str, RiskClass]]
+    ) -> dict:
+        if not write_actions:
+            return {}
+        normalized = {}
+        for name, risk in write_actions.items():
+            normalized[str(name)] = risk if isinstance(risk, RiskClass) else RiskClass(str(risk))
+        return normalized
 
     def submit(self, intent: OperatorIntent) -> OperatorResult:
         bound = self.context.bind(intent)
@@ -137,6 +166,13 @@ class OperatorIntentRuntime:
                 message_code="operation.confirmation_required",
             )
 
+        # A confirmed operation that is a registered external write action is
+        # dispatched through the controlled request/approval contract (#18). The
+        # intent confirmation IS the human approval. Everything else stays at the
+        # registered-executor boundary, unchanged.
+        if operation in self.write_actions and self.request_manager is not None:
+            return self._dispatch_external_action(intent, operation)
+
         status = "dry_run" if self.dry_run else "ready_for_registered_executor"
         code = "operation.dry_run" if self.dry_run else "operation.ready"
         return OperatorResult(
@@ -150,6 +186,58 @@ class OperatorIntentRuntime:
                 "target_ref": intent.target_ref,
                 "context_ref": intent.context_ref,
             },
+            message_code=code,
+        )
+
+    def _dispatch_external_action(self, intent: OperatorIntent, operation: str) -> OperatorResult:
+        """Run a confirmed write operation through the controlled request contract.
+
+        The manager records submit/approve/dispatch in its audit trail. The
+        external executor keeps final authority and may still reject an
+        approved request; under DRY_RUN nothing is sent to the executor.
+        """
+        manager = self.request_manager
+        manager.dry_run = self.dry_run  # honour the runtime's field-tuning switch
+        parameters = {k: v for k, v in dict(intent.parameters).items() if k != "operation"}
+        request = ActionRequest(
+            action=operation,
+            parameters=parameters,
+            target_ref=intent.target_ref,
+            context_ref=intent.context_ref,
+            risk_class=self.write_actions[operation],
+            requested_by_modality=intent.source_modality.value,
+            correlation_id=intent.correlation_id,
+            audit_id=intent.audit_id,
+        )
+        manager.submit(request)
+        manager.approve(request.request_id, intent.source_modality.value)
+        state = manager.dispatch(request.request_id, self.action_executor, modality=intent.source_modality.value)
+        result = manager.result_of(request.request_id)
+
+        payload = {
+            "operation": operation,
+            "target_ref": intent.target_ref,
+            "context_ref": intent.context_ref,
+            "request_id": request.request_id,
+            "request_state": state.value,
+            "external_ref": result.external_ref if result else None,
+            "detail": result.detail if result else None,
+        }
+        if state.value == "completed" and self.dry_run:
+            return self._operation_result(intent, "dry_run", "operation.dry_run", payload)
+        if state.value == "completed":
+            return self._operation_result(intent, "completed", "operation.completed", payload)
+        code = "operation.executor_rejected" if (result and result.rejected_by_executor) else "operation.failed"
+        return self._operation_result(intent, "failed", code, payload)
+
+    def _operation_result(self, intent: OperatorIntent, status: str, code: str, payload: dict) -> OperatorResult:
+        return OperatorResult(
+            intent_id=intent.intent_id,
+            status=status,
+            correlation_id=intent.correlation_id,
+            audit_id=intent.audit_id,
+            confirmation_id=intent.confirmation_id,
+            payload=payload,
             message_code=code,
         )
 

--- a/docs/request-contract.md
+++ b/docs/request-contract.md
@@ -72,12 +72,32 @@ metadata for the full lifecycle.
 
 ## Relationship to the canonical intent runtime
 
-`OperatorIntentRuntime` today stops registered `operation.run` at
-`confirmation_required` and represents DRY_RUN; it does not itself perform
-external writes. Wiring a confirmed operation into a `ControlledRequestManager`
-request (and an Azazel-Edge `ActionExecutor`) is the integration point for the
-future "M.I.O, isolate the target" flow, which must still end at Azazel-Edge's
-deterministic decision authority.
+`OperatorIntentRuntime` is wired to this contract for external write actions.
+Construct it with a `ControlledRequestManager`, an `action_executor`, and a
+`write_actions` allowlist (`{operation_name: RiskClass}`). A registered
+`operation.run` that is **not** in the allowlist still stops at the
+registered-executor boundary, unchanged. An operation that **is** in the
+allowlist follows this path once the operator confirms it (the intent
+confirmation is the human approval):
+
+```text
+"ミオ、対象を隔離"
+  -> operation.run (isolate.target)
+  -> confirmation_required        # human authority
+  -> operator approves            # resolve_pending(approved=True)
+  -> ControlledRequestManager: submit -> approve -> dispatch
+  -> AzazelEdgeActionExecutor.execute_action  # Edge decides
+  -> COMPLETED / FAILED (executor may reject)
+  -> M.I.O reports the result
+```
+
+`AzazelEdgeActionExecutor` (`babbly/adapters/azazel_edge_action.py`) POSTs a
+`babbly.action-proposal.v1` envelope to Azazel-Edge and interprets its decision.
+Edge keeps final authority: an unrecognized or rejecting decision fails closed.
+The write path is **disabled by default**; `create_action_executor` returns
+`None` unless `AZAZEL_EDGE_WRITE_ENABLED` is set and
+`AZAZEL_EDGE_WRITE_ACTIONS` lists at least one action. DRY_RUN completes the
+request without contacting Edge.
 
 ## Safety invariants
 

--- a/tests/test_azazel_edge_action.py
+++ b/tests/test_azazel_edge_action.py
@@ -1,0 +1,98 @@
+import io
+import json
+
+from babbly.adapters.azazel_edge_action import (
+    ACTION_PROPOSAL_SCHEMA,
+    AzazelEdgeActionExecutor,
+    interpret_edge_decision,
+    translate_action_request,
+)
+from babbly.adapters.factory import create_action_executor, parse_write_actions
+from babbly.core.request import ActionRequest, RiskClass
+
+
+class FakeResponse:
+    def __init__(self, body: bytes, status: int = 200):
+        self._buf = io.BytesIO(body)
+        self._status = status
+
+    def getcode(self):
+        return self._status
+
+    def read(self, n=-1):
+        return self._buf.read(n)
+
+    def close(self):
+        pass
+
+
+def _opener(body, status=200, capture=None):
+    def opener(request, timeout=None):
+        if capture is not None:
+            capture["request"] = request
+        return FakeResponse(body, status)
+    return opener
+
+
+def _request():
+    return ActionRequest(action="isolate.target", parameters={"scope": "host"}, target_ref="target-A",
+                         risk_class=RiskClass.HIGH, requested_by_modality="voice")
+
+
+def test_translate_has_no_shell_string():
+    env = translate_action_request(_request())
+    assert env["schema_version"] == ACTION_PROPOSAL_SCHEMA
+    assert env["action"] == "isolate.target"
+    assert env["target"] == "target-A"
+    assert "command" not in env and "shell" not in env
+
+
+def test_interpret_decisions():
+    assert interpret_edge_decision({"decision": "approved", "external_ref": "e1"}).ok is True
+    rej = interpret_edge_decision({"decision": "rejected", "reason": "policy"})
+    assert rej.ok is False and rej.rejected_by_executor is True
+    unknown = interpret_edge_decision({"decision": "wat"})
+    assert unknown.ok is False and unknown.rejected_by_executor is True
+    empty = interpret_edge_decision({})
+    assert empty.ok is False and empty.rejected_by_executor is False  # no decision -> fail closed, not a denial
+
+
+def test_executor_posts_proposal_and_reads_approval():
+    capture = {}
+    body = json.dumps({"decision": "approved", "external_ref": "edge-9", "detail": "done"}).encode()
+    ex = AzazelEdgeActionExecutor("http://127.0.0.1:8084", token="t0k", opener=_opener(body, capture=capture))
+    result = ex.execute_action(_request())
+    assert result.ok is True and result.external_ref == "edge-9"
+    sent = capture["request"]
+    assert sent.method == "POST"
+    assert sent.full_url == "http://127.0.0.1:8084/api/action"
+    assert sent.headers.get("X-azazel-token") == "t0k"
+    assert json.loads(sent.data.decode())["action"] == "isolate.target"
+
+
+def test_executor_http_error_is_not_an_authoritative_denial():
+    ex = AzazelEdgeActionExecutor("http://127.0.0.1:8084", opener=_opener(b"", status=503))
+    result = ex.execute_action(_request())
+    assert result.ok is False and result.rejected_by_executor is False
+
+
+def test_executor_invalid_json_fails_closed():
+    ex = AzazelEdgeActionExecutor("http://127.0.0.1:8084", opener=_opener(b"{not json"))
+    result = ex.execute_action(_request())
+    assert result.ok is False and result.rejected_by_executor is False
+
+
+def test_factory_disabled_by_default_and_requires_actions():
+    assert create_action_executor({}) is None
+    assert create_action_executor({"AZAZEL_EDGE_WRITE_ENABLED": True}) is None  # no actions
+    executor = create_action_executor(
+        {"AZAZEL_EDGE_WRITE_ENABLED": True, "AZAZEL_EDGE_WRITE_ACTIONS": ["isolate.target"],
+         "AZAZEL_EDGE_URL": "http://127.0.0.1:8084"}
+    )
+    assert isinstance(executor, AzazelEdgeActionExecutor)
+
+
+def test_parse_write_actions_forms():
+    assert parse_write_actions({"AZAZEL_EDGE_WRITE_ACTIONS": ["a", "b"]}) == {"a": RiskClass.HIGH, "b": RiskClass.HIGH}
+    assert parse_write_actions({"AZAZEL_EDGE_WRITE_ACTIONS": {"a": "low"}}) == {"a": RiskClass.LOW}
+    assert parse_write_actions({}) == {}

--- a/tests/test_controlled_operation_dispatch.py
+++ b/tests/test_controlled_operation_dispatch.py
@@ -1,0 +1,95 @@
+from babbly.core.operator_intent import OperatorIntent, SourceModality
+from babbly.core.operator_runtime import OperatorIntentRuntime
+from babbly.core.request import ActionRequest, ControlledRequestManager, ExecutionResult, RiskClass
+
+
+class FakeClock:
+    def __init__(self):
+        self.now = 1000.0
+
+    def __call__(self):
+        return self.now
+
+
+class RecordingExecutor:
+    def __init__(self, result):
+        self.result = result
+        self.calls = []
+
+    def execute_action(self, request: ActionRequest) -> ExecutionResult:
+        self.calls.append(request)
+        return self.result
+
+
+def _wired_runtime(executor, *, dry_run=False):
+    return OperatorIntentRuntime(
+        dry_run=dry_run,
+        request_manager=ControlledRequestManager(clock=FakeClock()),
+        action_executor=executor,
+        write_actions={"isolate.target": RiskClass.HIGH},
+    )
+
+
+def _confirm_operation(runtime, operation, *, target="target-A", modality=SourceModality.VOICE):
+    runtime.submit(
+        OperatorIntent(intent_id="operation.run", source_modality=modality,
+                       parameters={"operation": operation}, target_ref=target)
+    )
+    return runtime.resolve_pending(True, SourceModality.WEB)
+
+
+def test_confirmed_write_action_dispatches_through_contract():
+    executor = RecordingExecutor(ExecutionResult(ok=True, external_ref="edge-7", detail="isolated"))
+    runtime = _wired_runtime(executor)
+    result = _confirm_operation(runtime, "isolate.target")
+    assert result.status == "completed"
+    assert result.message_code == "operation.completed"
+    assert result.payload["external_ref"] == "edge-7"
+    assert [r.action for r in executor.calls] == ["isolate.target"]
+    # the full lifecycle is auditable
+    events = [e["event"] for e in runtime.request_manager.audit_log]
+    assert events == ["submit", "approve", "dispatch"]
+
+
+def test_executor_rejection_is_reported_and_authoritative():
+    executor = RecordingExecutor(ExecutionResult(ok=False, rejected_by_executor=True, detail="edge policy denied"))
+    runtime = _wired_runtime(executor)
+    result = _confirm_operation(runtime, "isolate.target")
+    assert result.status == "failed"
+    assert result.message_code == "operation.executor_rejected"
+    assert result.payload["detail"] == "edge policy denied"
+
+
+def test_dry_run_does_not_call_executor():
+    executor = RecordingExecutor(ExecutionResult(ok=True))
+    runtime = _wired_runtime(executor, dry_run=True)
+    result = _confirm_operation(runtime, "isolate.target")
+    assert result.status == "dry_run"
+    assert result.message_code == "operation.dry_run"
+    assert executor.calls == []
+
+
+def test_non_write_operation_stays_at_registered_boundary():
+    executor = RecordingExecutor(ExecutionResult(ok=True))
+    runtime = _wired_runtime(executor)
+    result = _confirm_operation(runtime, "recon-alpha")  # not in write_actions
+    assert result.status == "ready_for_registered_executor"
+    assert result.message_code == "operation.ready"
+    assert executor.calls == []
+
+
+def test_without_manager_write_wiring_is_inactive():
+    runtime = OperatorIntentRuntime(write_actions={"isolate.target": RiskClass.HIGH})  # no manager
+    result = _confirm_operation(runtime, "isolate.target")
+    assert result.status == "ready_for_registered_executor"
+
+
+def test_confirmation_is_still_required_before_dispatch():
+    executor = RecordingExecutor(ExecutionResult(ok=True))
+    runtime = _wired_runtime(executor)
+    pending = runtime.submit(
+        OperatorIntent(intent_id="operation.run", source_modality=SourceModality.VOICE,
+                       parameters={"operation": "isolate.target"}, target_ref="target-A")
+    )
+    assert pending.status == "confirmation_required"
+    assert executor.calls == []  # nothing dispatched before approval


### PR DESCRIPTION
## Summary
Completes the "M.I.O, isolate the target" end-to-end path (item 1). A confirmed `operation.run` that is a **registered external write action** now flows through the controlled request/approval contract (#18) to an external executor; every other operation stays at the registered-executor boundary, unchanged.

```text
"ミオ、対象を隔離" -> operation.run -> confirmation_required -> operator approves
  -> ControlledRequestManager: submit -> approve -> dispatch
  -> AzazelEdgeActionExecutor.execute_action  (Edge decides)
  -> COMPLETED / FAILED (executor may reject) -> M.I.O reports result
```

- `OperatorIntentRuntime` gains optional `request_manager`, `action_executor`, and a `write_actions` allowlist. The intent confirmation **is** the human approval; DRY_RUN never contacts the executor.
- `AzazelEdgeActionExecutor` POSTs a `babbly.action-proposal.v1` envelope and interprets Edge's decision. **Edge keeps final authority**; an unrecognized/rejecting decision fails closed. Bounded, token-authenticated, opener-injectable, no shell string.
- Write path **disabled by default** (`create_action_executor` needs `AZAZEL_EDGE_WRITE_ENABLED` + `AZAZEL_EDGE_WRITE_ACTIONS`).

## Safety
- read-only Situation model untouched; external write is a separate typed contract
- confirmation still required before any dispatch; executor may reject an approved request
- no operation gains a write path unless explicitly allowlisted; standalone/read-only behaviour unchanged

## Validation
- `python -m pytest -q tests` → 137 passed (+13).
- `python -m compileall -q babbly tools tests` → OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)