### PR TITLE
feat: activate attention modes, controlled write path, and shared-runtime Web in the live app (A)

### DIFF
--- a/babbly/core/runtime_factory.py
+++ b/babbly/core/runtime_factory.py
@@ -1,0 +1,47 @@
+"""Factory for the optionally controlled operator runtime."""
+
+from __future__ import annotations
+
+from typing import Mapping, Optional
+
+from babbly.adapters.factory import create_action_executor, parse_write_actions
+from babbly.core.engine import SituationEngine
+from babbly.core.operator_runtime import OperatorIntentRuntime
+from babbly.core.request import ControlledRequestManager
+
+
+def build_operator_runtime(
+    config: Mapping[str, object], situation_engine: Optional[SituationEngine] = None
+) -> OperatorIntentRuntime:
+    """Build an OperatorIntentRuntime wired from config.
+
+    Always sets DRY_RUN. When the controlled write path is enabled in config
+    (create_action_executor returns an executor AND parse_write_actions is
+    non-empty), also wires a ControlledRequestManager, the Azazel-Edge action
+    executor, and the write-action allowlist. Otherwise returns a runtime with
+    no write path (unchanged read/confirmation behaviour).
+    """
+    dry_run = bool(config.get("DRY_RUN", False))
+    executor = create_action_executor(config)
+    write_actions = parse_write_actions(config)
+
+    if executor is not None and write_actions:
+        request_manager = ControlledRequestManager(
+            dry_run=dry_run,
+            default_timeout_seconds=float(
+                config.get("AZAZEL_EDGE_APPROVAL_TIMEOUT_SEC", 120.0)
+            ),
+        )
+        action_executor = executor
+    else:
+        request_manager = None
+        action_executor = None
+        write_actions = None
+
+    return OperatorIntentRuntime(
+        situation_engine,
+        dry_run=dry_run,
+        request_manager=request_manager,
+        action_executor=action_executor,
+        write_actions=write_actions,
+    )

--- a/babbly/ja/config_ja.yaml
+++ b/babbly/ja/config_ja.yaml
@@ -62,3 +62,19 @@ AZAZEL_EDGE_TOKEN_FILE: ""
 AZAZEL_EDGE_TIMEOUT_SEC: 2.0
 AZAZEL_EDGE_CACHE_TTL_SEC: 1.0
 AZAZEL_EDGE_MAX_RESPONSE_BYTES: 1048576
+
+# Controlled write path (#18). Disabled by default: a confirmed operation stays
+# at the registered-executor boundary unless it is BOTH enabled here AND listed
+# in AZAZEL_EDGE_WRITE_ACTIONS. Even then, the operator must confirm each action
+# and Azazel-Edge keeps final decision authority. Profiles cannot change this.
+AZAZEL_EDGE_WRITE_ENABLED: false
+AZAZEL_EDGE_WRITE_ACTIONS: []
+AZAZEL_EDGE_ACTION_PATH: "/api/action"
+AZAZEL_EDGE_APPROVAL_TIMEOUT_SEC: 120.0
+
+# Optional compact Web/EUD surface, served in a background thread bound to the
+# same runtime as the voice loop (shared target/attention/pending state). Binds
+# loopback by default. Presentation/input only; it exposes no write intents.
+WEB_SURFACE_ENABLED: false
+WEB_SURFACE_HOST: "127.0.0.1"
+WEB_SURFACE_PORT: 8787

--- a/babbly/ja/main_program.py
+++ b/babbly/ja/main_program.py
@@ -10,7 +10,11 @@ from babbly.asr import create_asr
 from babbly.core.engine import SituationEngine
 from babbly.core.operator_intent import OperatorIntent, SourceModality
 from babbly.core.operator_runtime import OperatorIntentRuntime
-from babbly.core.render import render_recommendation_ja, render_situation_ja
+from babbly.core.render import (
+    render_recommendation_for_attention,
+    render_situation_for_attention,
+)
+from babbly.core.runtime_factory import build_operator_runtime
 from babbly.core.situation import SituationSnapshot
 from babbly.ja.japanese_tts import Japanese_TTS
 from babbly.modules.commands_manager import CommandManager
@@ -43,6 +47,18 @@ def set_agent_profile(profile):
     """Set identity/persona metadata; this does not grant execution authority."""
     global agent_profile
     agent_profile = profile
+
+
+def configure_operator_runtime(config, engine):
+    """Rebuild the shared operator runtime from config.
+
+    Activates the controlled write path (#18) only when the config enables it;
+    otherwise the runtime keeps the read/confirmation-only behaviour. Binds the
+    read-only situation engine.
+    """
+    global situation_engine, operator_runtime
+    situation_engine = engine
+    operator_runtime = build_operator_runtime(config, engine)
 
 
 def set_globals(config):
@@ -126,7 +142,8 @@ def report_dry_run(action, detail=""):
 def speak_situation_report(confidence=None):
     result = operator_runtime.submit(_voice_intent("situation.report", confidence=confidence))
     snapshot = SituationSnapshot.from_dict(result.payload.get("snapshot", {}))
-    message = render_situation_ja(snapshot)
+    # Render at the current operator-attention density (NORMAL/HEADS_UP/CRITICAL).
+    message = render_situation_for_attention(snapshot, operator_runtime.attention.state)
     print(message)
     tts.say(message)
 
@@ -134,9 +151,36 @@ def speak_situation_report(confidence=None):
 def speak_recommendation(confidence=None):
     result = operator_runtime.submit(_voice_intent("recommendation.explain", confidence=confidence))
     snapshot = SituationSnapshot.from_dict(result.payload.get("snapshot", {}))
-    message = render_recommendation_ja(snapshot)
+    message = render_recommendation_for_attention(snapshot, operator_runtime.attention.state)
     print(message)
     tts.say(message)
+
+
+# Operator-controlled attention mode switch via voice. This changes presentation
+# density only; it never changes execution authority or confirmation policy.
+_ATTENTION_PHRASES = (
+    ("ヘッドアップ", "heads_up"),
+    ("ヘッズアップ", "heads_up"),
+    ("クリティカル", "critical"),
+    ("ノーマル", "normal"),
+    ("通常モード", "normal"),
+)
+_ATTENTION_LABELS = {"normal": "通常", "heads_up": "ヘッドアップ", "critical": "クリティカル"}
+
+
+def maybe_set_attention(normalized):
+    """Handle a spoken attention-mode change; return True if one was applied."""
+    for phrase, state in _ATTENTION_PHRASES:
+        if phrase in normalized:
+            result = operator_runtime.submit(
+                _voice_intent("attention.set", parameters={"state": state})
+            )
+            if result.status == "ok":
+                message = f"注意モードを{_ATTENTION_LABELS[state]}に切り替えました"
+                print(message)
+                tts.say(message)
+                return True
+    return False
 
 
 def wait_for_wakeup(wake_detector, asr):
@@ -199,6 +243,11 @@ def listen_for_command(asr):
                 print("終了フレーズ認識。処理を終了します。")
                 tts.say(_persona_value("shutdown_phrase", "システムを終了します。お疲れ様でした。"))
                 raise SystemExit(0)
+
+            # Presentation-only attention switch. No confidence gate: it grants
+            # no execution authority and only changes rendering density.
+            if maybe_set_attention(normalized):
+                break
 
             if intent.name != "unknown" and policy.decision == Decision.CLARIFY:
                 if not ask_confirmation(asr, f"{recog_text}、という指示でよろしいですか"):
@@ -286,6 +335,26 @@ def listen_for_command(asr):
                 if DRY_RUN:
                     report_dry_run("operation", op_name)
                     break
+                # A confirmed external write action (#18) is dispatched by the
+                # runtime and reports its own result; Azazel-Edge keeps final
+                # authority and may reject it.
+                if resolved.status == "completed":
+                    detail = resolved.payload.get("detail")
+                    message = f"オペレーション {op_name} を実行しました"
+                    if detail:
+                        message += f"。{detail}"
+                    print(message)
+                    tts.say(message)
+                    break
+                if resolved.status == "failed":
+                    detail = resolved.payload.get("detail") or ""
+                    message = f"オペレーション {op_name} は承認先で拒否または失敗しました"
+                    if detail:
+                        message += f"。{detail}"
+                    print(message)
+                    tts.say(message)
+                    break
+                # Otherwise this is a registered local operation (SOP boundary).
                 if resolved.status != "ready_for_registered_executor":
                     tts.say("オペレーションを実行可能な状態にできませんでした")
                     continue
@@ -343,7 +412,7 @@ def main(argv=None):
     config = apply_profile_to_config(base_config, profile)
     set_agent_profile(profile)
     set_globals(config)
-    set_situation_engine(create_situation_engine(config))
+    configure_operator_runtime(config, create_situation_engine(config))
 
     ascii_art = pyfiglet.figlet_format(profile.identity.display_name, font="dos_rebel")
     print(ascii_art)
@@ -366,11 +435,28 @@ def main(argv=None):
         config.get("WAKE_BACKEND", "asr"),
     )
 
+    # Optionally serve the compact Web/EUD surface in a background thread bound
+    # to THIS shared runtime, so voice and the wearable EUD keep one target,
+    # attention state, and pending confirmation.
+    web_server = None
+    if bool(config.get("WEB_SURFACE_ENABLED", False)):
+        from babbly.web.server import start_web_surface
+
+        web_host = str(config.get("WEB_SURFACE_HOST", "127.0.0.1"))
+        web_port = int(config.get("WEB_SURFACE_PORT", 8787))
+        web_server, _web_thread = start_web_surface(operator_runtime, host=web_host, port=web_port)
+        print(f"Web surface: http://{web_host}:{web_port} (shared runtime)")
+
     print("＜音声認識開始 - 入力を待機します＞")
     if DRY_RUN:
         print("DRY_RUN is enabled: executable actions will be suppressed")
     tts.say(profile.persona.startup_phrase)
-    wait_for_wakeup(wake_detector, asr)
+    try:
+        wait_for_wakeup(wake_detector, asr)
+    finally:
+        if web_server is not None:
+            web_server.shutdown()
+            web_server.server_close()
 
 
 if __name__ == '__main__':

--- a/babbly/web/server.py
+++ b/babbly/web/server.py
@@ -19,6 +19,7 @@ without the offline voice/ASR stack.
 from __future__ import annotations
 
 import json
+import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any, Dict, Optional, Tuple
 
@@ -147,13 +148,33 @@ def make_server(app: SituationWebApp, host: str = "127.0.0.1", port: int = 8787)
     return ThreadingHTTPServer((host, port), _Handler)
 
 
+def start_web_surface(
+    runtime: Optional[OperatorIntentRuntime] = None,
+    host: str = "127.0.0.1",
+    port: int = 8787,
+    *,
+    endpoint: Optional[CoreSessionEndpoint] = None,
+) -> Tuple[ThreadingHTTPServer, threading.Thread]:
+    """Start the Situation surface in a daemon thread bound to a shared runtime.
+
+    Returns (server, thread). The caller (e.g. the voice loop) keeps running;
+    call server.shutdown()/server.server_close() to stop. Pass either a shared
+    `runtime` or an existing `CoreSessionEndpoint` via `endpoint`.
+    """
+    app = SituationWebApp(runtime, endpoint=endpoint)
+    server = make_server(app, host, port)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread
+
+
 def serve(host: str = "127.0.0.1", port: int = 8787, runtime: Optional[OperatorIntentRuntime] = None) -> None:
     """Run the Situation surface until interrupted (local prototype; binds loopback)."""
-    app = SituationWebApp(runtime)
-    server = make_server(app, host, port)
+    server, thread = start_web_surface(runtime, host, port)
     print(f"Babbly Situation surface on http://{host}:{port}")
     try:
-        server.serve_forever()
+        while thread.is_alive():
+            thread.join(timeout=1.0)
     except KeyboardInterrupt:
         pass
     finally:

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -31,6 +31,12 @@ Implemented on this branch:
   and full command ASR, so idle operation does not run full ASR continuously
 - offline wake benchmark corpus and FAR/FRR/latency evaluator
   (`tools/evaluate_wake_results.py`)
+- live JA voice app wiring (`babbly/ja/main_program.py`): builds the runtime via
+  `build_operator_runtime` so the controlled write path activates from config
+  (`AZAZEL_EDGE_WRITE_ENABLED` + `AZAZEL_EDGE_WRITE_ACTIONS`, default off);
+  renders situation/recommendation at the current attention density and switches
+  attention mode by voice; and can serve the Web/EUD surface in a background
+  thread bound to the same runtime (`WEB_SURFACE_ENABLED`, default off)
 - full tests and GitHub Actions coverage
 
 Not implemented yet:

--- a/tests/test_runtime_factory.py
+++ b/tests/test_runtime_factory.py
@@ -1,0 +1,46 @@
+from babbly.adapters.azazel_edge_action import AzazelEdgeActionExecutor
+from babbly.core.engine import SituationEngine
+from babbly.core.request import ControlledRequestManager, RiskClass
+from babbly.core.runtime_factory import build_operator_runtime
+
+
+def test_default_config_has_no_write_path():
+    runtime = build_operator_runtime({})
+
+    assert runtime.request_manager is None
+    assert runtime.action_executor is None
+    assert runtime.write_actions == {}
+
+
+def test_dry_run_config_propagates_to_runtime():
+    runtime = build_operator_runtime({"DRY_RUN": True})
+
+    assert runtime.dry_run is True
+
+
+def test_enabled_write_path_is_fully_wired():
+    runtime = build_operator_runtime(
+        {
+            "AZAZEL_EDGE_WRITE_ENABLED": True,
+            "AZAZEL_EDGE_WRITE_ACTIONS": ["isolate.target"],
+            "AZAZEL_EDGE_URL": "http://127.0.0.1:8084",
+        }
+    )
+
+    assert isinstance(runtime.request_manager, ControlledRequestManager)
+    assert runtime.write_actions == {"isolate.target": RiskClass.HIGH}
+    assert isinstance(runtime.action_executor, AzazelEdgeActionExecutor)
+
+
+def test_enabled_write_path_without_actions_is_disabled():
+    runtime = build_operator_runtime({"AZAZEL_EDGE_WRITE_ENABLED": True})
+
+    assert runtime.request_manager is None
+
+
+def test_passed_situation_engine_is_used():
+    situation_engine = SituationEngine()
+
+    runtime = build_operator_runtime({}, situation_engine=situation_engine)
+
+    assert runtime.situation_engine is situation_engine

--- a/tests/test_web_surface.py
+++ b/tests/test_web_surface.py
@@ -5,7 +5,7 @@ import urllib.request
 from babbly.core.attention import OperatorAttentionState
 from babbly.core.operator_runtime import OperatorIntentRuntime
 from babbly.core.situation import Observation, Recommendation, SituationSnapshot
-from babbly.web.server import SituationWebApp, make_server
+from babbly.web.server import SituationWebApp, make_server, start_web_surface
 
 
 class _FakeEngine:
@@ -131,6 +131,32 @@ def test_end_to_end_over_a_real_socket():
             assert resp.status == 200
             env = json.loads(resp.read().decode("utf-8"))
             assert env["view"]["schema"] == "babbly.situation-view.v1"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_start_web_surface_shares_runtime():
+    runtime = OperatorIntentRuntime(situation_engine=_FakeEngine(_snapshot()))
+    server, thread = start_web_surface(runtime, host="127.0.0.1", port=0)
+    try:
+        port = server.server_address[1]
+        with urllib.request.urlopen(f"http://127.0.0.1:{port}/api/situation", timeout=5) as resp:
+            assert resp.status == 200
+            env = json.loads(resp.read().decode("utf-8"))
+        view = env["view"]
+        assert view["attention_state"] == "normal"
+
+        # Mutate the shared runtime directly; the served surface must reflect it,
+        # proving the web surface and this runtime share the same state.
+        runtime.attention.request_state("critical", "test")
+
+        with urllib.request.urlopen(f"http://127.0.0.1:{port}/api/situation", timeout=5) as resp:
+            assert resp.status == 200
+            env = json.loads(resp.read().decode("utf-8"))
+        view = env["view"]
+        assert view["attention_state"] == "critical"
     finally:
         server.shutdown()
         server.server_close()


### PR DESCRIPTION
## Summary
Wires the already-built contracts into the **live JA voice agent** so one running deployment exercises them as a single system. Implemented with subagents as requested: the **runtime factory by Codex (`codex exec`)**, the **background Web serve by a Sonnet 5 subagent**, and the `main_program` integration here.

### ② Controlled write path activates from config (#18)
- `babbly/core/runtime_factory.py` (Codex): `build_operator_runtime(config, engine)` wires `ControlledRequestManager` + the Azazel-Edge executor + the write-action allowlist **only when** `AZAZEL_EDGE_WRITE_ENABLED` + `AZAZEL_EDGE_WRITE_ACTIONS` are set (default off); otherwise a plain runtime.
- `main_program` reports external write outcomes (`completed`/`failed`) from a confirmed `operation.run`, while the registered-SOP path is unchanged.

### ① Attention modes in the voice loop (#16)
- Situation/recommendation are rendered at `operator_runtime.attention` density (progressive disclosure).
- Voice mode switch: 「ノーマル / ヘッドアップ / クリティカル」→ `attention.set` (presentation only; no confidence gate, no new authority).

### ③ Web EUD shares the voice runtime (#19)
- `babbly/web/server.py` (Sonnet 5): `start_web_surface(runtime, ...)` serves in a daemon thread bound to a shared runtime; `serve()` reuses it.
- `main_program` optionally launches it (`WEB_SURFACE_ENABLED`, default off) bound to the **same** runtime, so voice and the wearable EUD share target/attention/pending state.

## Safety
Attention/profile/session change presentation only. The write path needs explicit config **and** per-action operator confirmation, read-only adapters can't satisfy it, and Azazel-Edge keeps final authority. All defaults are off, so standalone behaviour is unchanged.

## Validation
- `python -m pytest -q tests` → 145 passed (+6: runtime_factory ×5, shared-runtime web ×1).
- `python -m compileall -q babbly tools tests` → OK; `import babbly.ja.main_program` OK; `--list-profiles` OK (venv).
- End-to-end (no audio stack): config-activated write path + a Web `attention.set` mutating the shared runtime's attention (normal→critical).

Part of the "A" software-integration tier; the offline ASR model (B) and field/hardware runs (#14/#20/#21) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)