### PR TITLE
chore: add offline Vosk ASR model provisioning (B)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ speech.txt
 speech.wav
 .venv/
 results/
+babbly/ja/model/

--- a/docs/development-macos.md
+++ b/docs/development-macos.md
@@ -48,9 +48,23 @@ python -m pip install "pytest>=8,<10"
 ```
 
 The offline ASR model is a separate, uncommitted asset. `vosk` expects a model
-directory at `MODEL_PATH` (default `babbly/ja/model`); provision it before
-running the full voice loop. Tests, `--list-profiles`, and profile/DRY_RUN
-startup do not require the model.
+directory at `MODEL_PATH` (default `babbly/ja/model`). Provision it before
+running the full voice loop:
+
+```bash
+./tools/provision_vosk_model.sh
+# or the larger, more accurate model for production/Pi:
+VOSK_MODEL=vosk-model-ja-0.22 ./tools/provision_vosk_model.sh
+```
+
+The script downloads and unpacks the model into `babbly/ja/model/` (gitignored)
+and is idempotent. Tests, `--list-profiles`, and profile/DRY_RUN startup do not
+require the model.
+
+The offline Japanese TTS (`pyopenjtalk`) downloads its dictionary
+(`open_jtalk_dic`, ~22 MB) automatically on first speech and caches it in the
+package. For a fully disconnected host, trigger one online run first so the
+dictionary is cached before going offline.
 
 Run tests:
 

--- a/tools/provision_vosk_model.sh
+++ b/tools/provision_vosk_model.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Provision the offline Vosk Japanese ASR model into MODEL_PATH (babbly/ja/model).
+#
+# The model is a large, uncommitted asset. This script downloads and unpacks it
+# so the offline voice loop can run. Idempotent: it is a no-op if a model is
+# already present.
+#
+# Defaults to the small Japanese model (~50 MB), good for MacBook development.
+# For production/Pi accuracy, set VOSK_MODEL=vosk-model-ja-0.22 (~1 GB).
+#
+#   ./tools/provision_vosk_model.sh
+#   VOSK_MODEL=vosk-model-ja-0.22 ./tools/provision_vosk_model.sh
+#   MODEL_DIR=/opt/babbly/model ./tools/provision_vosk_model.sh
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+MODEL_DIR="${MODEL_DIR:-$ROOT_DIR/babbly/ja/model}"
+MODEL_NAME="${VOSK_MODEL:-vosk-model-small-ja-0.22}"
+BASE_URL="${VOSK_BASE_URL:-https://alphacephei.com/vosk/models}"
+URL="$BASE_URL/${MODEL_NAME}.zip"
+
+if [[ -f "$MODEL_DIR/conf/model.conf" || -f "$MODEL_DIR/am/final.mdl" ]]; then
+  echo "Vosk model already present at $MODEL_DIR — nothing to do."
+  exit 0
+fi
+
+for tool in curl unzip; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "error: '$tool' is required" >&2; exit 2; }
+done
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+echo "Downloading $URL ..."
+curl -fL --retry 3 -o "$tmp/model.zip" "$URL"
+
+echo "Unpacking ..."
+unzip -q "$tmp/model.zip" -d "$tmp"
+
+src="$tmp/$MODEL_NAME"
+if [[ ! -d "$src" ]]; then
+  src="$(find "$tmp" -maxdepth 1 -type d -name 'vosk-model-*' | head -1)"
+fi
+if [[ -z "${src:-}" || ! -d "$src" ]]; then
+  echo "error: could not locate the unpacked model directory" >&2
+  exit 3
+fi
+
+mkdir -p "$(dirname "$MODEL_DIR")"
+rm -rf "$MODEL_DIR"
+mv "$src" "$MODEL_DIR"
+
+echo "Vosk model '$MODEL_NAME' provisioned at $MODEL_DIR"


### PR DESCRIPTION
## Summary
Completes tier **B**: reproducible provisioning of the offline ASR model so the full voice loop runs on the Mac.

- `tools/provision_vosk_model.sh`: idempotent download + unpack of the Vosk Japanese model into `MODEL_PATH` (`babbly/ja/model`). Defaults to the small model (~50 MB) for development; `VOSK_MODEL=vosk-model-ja-0.22` selects the ~1 GB model. `MODEL_DIR=…` overrides the target.
- `.gitignore`: ignore `babbly/ja/model/` (large, uncommitted asset).
- `docs/development-macos.md`: document the script and the one-time `pyopenjtalk` dictionary download on first speech.

## Verified
- Ran the script → model unpacked to `babbly/ja/model/` (am/conf/graph/ivector); git ignores it; second run is a no-op.
- `./run_babbly.sh ja --profile generic` (DRY_RUN) now boots **past ASR model creation** to `＜音声認識開始 - 入力を待機します＞` / the wake-wait stage — no more `Failed to create a model`.
- `python -m pytest -q tests` → 145 passed; `compileall` OK (script/docs only).

After this, the Mac can run the voice agent end-to-end (mic permitting); remaining work is tier **C** (Pi #14, forearm field #20, human-factors runs #21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)